### PR TITLE
allow cli port specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Issue the command `live-server` in your project's directory. Alternatively you c
 
 This will automatically launch the default browser (you should have `index.html` present). When you make a change to any file, the browser will reload the page - unless it was a CSS file in which case the changes are applied without a reload.
 
-You can configure the port to be used by setting `PORT` environment variable prior to launching the server.
+You can configure the port to be used by the server by adding the `--port=<number>` runtime option when invoking live-server, or by setting the `PORT` environment variable prior to running live-server.
 
 
 Usage from node

--- a/live-server.js
+++ b/live-server.js
@@ -1,7 +1,20 @@
 #!/usr/bin/env node
 var liveServer = require("./index");
 
+var port = process.env.PORT;
+
+process.argv.forEach(function(v,idx) {
+	if (v.indexOf("--port=") >- 1) {
+		var portString = v.substring(7); 
+        var portNumber = parseInt(portString, 10);
+		if (portNumber == portString) {
+			port = portNumber;
+    		process.argv.splice(idx,1);
+    	}
+	}
+});
+
 if (process.argv[2])
 	process.chdir(process.argv[2]);
 
-liveServer.start(process.env.PORT);
+liveServer.start(port);


### PR DESCRIPTION
fixes #10 by having live-server check for a `--port=...` runtime option. If present, it will parse the argument and if a proper number, use it. If a bad string, or not provided, the `PORT` environment variable is use as is already the case.