### PR TITLE
Allow several directories

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,11 +74,18 @@ LiveServer.start = function(port, directory, suppressBrowserLaunch) {
 	port = port || 8080;
 	directory = directory || process.cwd();
 
+  if (!Array.isArray(directory))
+      directory = [directory];
+
 	// Setup a web server
 	var app = connect()
-		.use(staticServer(directory)) // Custom static server
-		.use(connect.directory(directory, { icons: true }))
 		.use(connect.logger('dev'));
+
+  directory.forEach(function (d) {
+		app.use(staticServer(d)) // Custom static server
+		app.use(connect.directory(d, { icons: true }))
+  });
+
 	var server = http.createServer(app).listen(port, '0.0.0.0');
 	// WebSocket
 	server.addListener('upgrade', function(request, socket, head) {
@@ -87,7 +94,7 @@ LiveServer.start = function(port, directory, suppressBrowserLaunch) {
 	});
 	// Setup file watcher
 	watchr.watch({
-		path: directory,
+		paths: directory,
 		ignoreCommonPatterns: true,
 		ignoreHiddenFiles: true,
 		preferredMethods: [ 'watchFile', 'watch' ],


### PR DESCRIPTION
Hi,

Thanks for this useful module. When working with npm I usually have my dependencies in  different directories than the source files and index file, and when using the source directory as the "root" it's not possible to access files in parent directories (logical). 

This change allows to do that, so I thought I'd send you a PR and see what you think.