### PR TITLE
Add --entry-point

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ You can configure the port to be used by the server by adding the `--port=<numbe
 
 Use parameter `--no-browser` to suppress automatic web browser launching.
 
+If you are developing a single-page application that uses HTML5's history API, you might enable the `--entry-point=<entry file>` option that basically redirects every not found request to this file.
+
 
 Usage from node
 ---------------
@@ -55,7 +57,8 @@ var params = {
 	port: 8181, // Set the server port. Defaults to 8080.
 	host: "0.0.0.0", // Set the address to bind to. Defaults to 0.0.0.0.
 	root: "/public", // Set root directory that's being server. Defaults to cwd.
-	noBrowser = true // When true, it won't load your browser by default.
+	noBrowser: true, // When true, it won't load your browser by default.
+	file: "index.html" // When set, redirect every 404 to this file (useful for single-page applications)
 };
 liveServer.start(params);
 ```

--- a/live-server.js
+++ b/live-server.js
@@ -16,6 +16,12 @@ for (var i = process.argv.length-1; i >= 2; --i) {
 			opts.port = portNumber;
 			process.argv.splice(i, 1);
 		}
+	} else if (arg.indexOf("--entry-point=") > -1) {
+		var file = arg.substring(14);
+		if (file.length) {
+			opts.file = file;
+			process.argv.splice(i, 1);
+		}
 	} else if (arg == "--no-browser") {
 		opts.noBrowser = true;
 		process.argv.splice(i, 1);
@@ -23,7 +29,7 @@ for (var i = process.argv.length-1; i >= 2; --i) {
 		opts.logLevel = 0;
 		process.argv.splice(i, 1);
 	} else if (arg == "--help" || arg == "-h") {
-		console.log('Usage: live-server [-h|--help] [--port=PORT] [--no-browser] [PATH]');
+		console.log('Usage: live-server [-h|--help] [-q|--quiet] [--port=PORT] [--no-browser] [--entry-point=ENTRYPOINT] [PATH]');
 		process.exit();
 	}
 }


### PR DESCRIPTION
Hi! I've used your application for my AngularJS development and recently wanted to enable the HTML5 history API (`$locationProvider.html5Mode(true)`). I added an option to add an “entry point” file, which will be rendered if a request doesn't have an associated file on the server.

TL;DR:

```
/index.html (existing file)     -> shows index.html
/css/styles.css (existing file) -> shows css/styles.css
/login (no file)                -> shows index.html
```