### PR TITLE
Add "--open" Option

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,7 +118,7 @@ LiveServer.start = function(options) {
 		}
 	});
 	// Output
-	var browserURL = "http://127.0.0.1:" + port;
+	var browserURL = "http://127.0.0.1:" + port + (options.open || '');
 	if (logLevel >= 1)
 		console.log(('Serving "' + root + '" at ' + browserURL).green);
 

--- a/index.js
+++ b/index.js
@@ -118,13 +118,13 @@ LiveServer.start = function(options) {
 		}
 	});
 	// Output
-	var browserURL = "http://127.0.0.1:" + port + (options.open || '');
+	var browserURL = "http://127.0.0.1:" + port;
 	if (logLevel >= 1)
 		console.log(('Serving "' + root + '" at ' + browserURL).green);
 
 	// Launch browser
-	if(!noBrowser)
-		open(browserURL);
+	if (!noBrowser)
+		open(browserURL + (options.open || ''));
 };
 
 module.exports = LiveServer;

--- a/live-server.js
+++ b/live-server.js
@@ -16,19 +16,29 @@ for (var i = process.argv.length-1; i >= 2; --i) {
 			opts.port = portNumber;
 			process.argv.splice(i, 1);
 		}
-	} else if (arg == "--no-browser") {
+	}
+	else if (arg.indexOf("--open=") > -1) {
+		var path = arg.substring(7);
+		if (path.indexOf('/') != 0) {
+			path = '/' + path;
+		}
+		opts.open = path;
+		process.argv.splice(i, 1);
+	}
+	else if (arg == "--no-browser") {
 		opts.noBrowser = true;
 		process.argv.splice(i, 1);
 	} else if (arg == "--quiet" || arg == "-q") {
 		opts.logLevel = 0;
 		process.argv.splice(i, 1);
 	} else if (arg == "--help" || arg == "-h") {
-		console.log('Usage: live-server [-h|--help] [--port=PORT] [--no-browser] [PATH]');
+		console.log('Usage: live-server [-h|--help] [-q|--quiet] [--port=PORT] [--open=PATH] [--no-browser] [PATH]');
 		process.exit();
 	}
 }
 
-if (process.argv[2])
+if (process.argv[2]) {
 	process.chdir(process.argv[2]);
+}
 
 liveServer.start(opts);


### PR DESCRIPTION
Adds the ability to specify a path to load in the browser: 
```
live-server --open=/test
```
My use-case is serving a Mocha html runner via `npm test`, where the runner requires a file that is in the directory above it, and therefore the `live-server` root cannot be changed to the subdirectory. It can also be useful in other situations as I envisage the `scripts` section in my package.json to look like this:
```json
"scripts": {
  "start": "live-server --open=/examples",
  "test": "live-server --open=/test --port=8081"
}
```
I've tried to stick to the current code style in my patch, but let me know if there are any problems.