### PR TITLE
Adds timeout parameter to delay the reload event when files change

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ var params = {
 	port: 8181, // Set the server port. Defaults to 8080.
 	host: "0.0.0.0", // Set the address to bind to. Defaults to 0.0.0.0.
 	root: "/public", // Set root directory that's being server. Defaults to cwd.
-	noBrowser: true // When true, it won't load your browser by default.
+	noBrowser: true, // When true, it won't load your browser by default.
+	timeout: 1000 // Sets the timeout in milliseconds before reloading the browser. Defaults to 0.
 };
 liveServer.start(params);
 ```

--- a/index.js
+++ b/index.js
@@ -79,6 +79,8 @@ LiveServer.start = function(options) {
 	var root = options.root || process.cwd();
 	var logLevel = options.logLevel === undefined ? 2 : options.logLevel;
 	var noBrowser = options.noBrowser || false;
+	var timeout = options.timeout || 0;
+	var timer;
 
 	// Setup a web server
 	var app = connect()
@@ -110,7 +112,14 @@ LiveServer.start = function(options) {
 					if (logLevel >= 1)
 						console.log("CSS change detected".magenta);
 				} else {
-					ws.send('reload');
+					if (timer) {
+						clearTimeout(timer);
+					}
+
+					timer = setTimeout(function() {
+						ws.send('reload');
+					}, timeout);
+
 					if (logLevel >= 1)
 						console.log("File change detected".cyan);
 				}

--- a/live-server.js
+++ b/live-server.js
@@ -22,8 +22,15 @@ for (var i = process.argv.length-1; i >= 2; --i) {
 	} else if (arg == "--quiet" || arg == "-q") {
 		opts.logLevel = 0;
 		process.argv.splice(i, 1);
+	} else if (arg.indexOf("--timeout=") > -1) {
+		var timeoutString = arg.substring(10);
+		var timeoutNumber = parseInt(timeoutString, 10);
+		if (timeoutNumber == timeoutString) {
+			opts.timeout = timeoutNumber;
+			process.argv.splice(i, 1);
+		}
 	} else if (arg == "--help" || arg == "-h") {
-		console.log('Usage: live-server [-h|--help] [--port=PORT] [--no-browser] [PATH]');
+		console.log('Usage: live-server [-h|--help] [--port=PORT] [--no-browser] [--timeout=MILLISECONDS] [PATH]');
 		process.exit();
 	}
 }


### PR DESCRIPTION
When using live-server along with a build process, sometimes on the build step you will generate several files almost at the same time and this ends up triggering more than one reload on the browser.

Adding a timeout parameter you can configure a delay and only trigger one reload event after all changes have been made.