### PR TITLE
Add option of providing default settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ Additional parameters:
 * `--quiet` - suppress logging
 * `--open=PATH` - launch browser to PATH instead of server root
 
+Default options:
+
+If a file `~/.live-server.json` exists it will be loaded and used as default options for live-server on the command line. See "Usage from node" for option names.
+
 
 Usage from node
 ---------------

--- a/live-server.js
+++ b/live-server.js
@@ -10,7 +10,9 @@ var opts = {
 	logLevel: 2
 };
 
-var configPath = path.join(process.env.HOME, '.live-server.json');
+var homeDir = process.env[(process.platform == 'win32') ?
+  'USERPROFILE' : 'HOME']
+var configPath = path.join(homeDir, '.live-server.json');
 if (fs.existsSync(configPath)) {
 	var userConfig = fs.readFileSync(configPath, 'utf8');
 	assign(opts, JSON.parse(userConfig));

--- a/live-server.js
+++ b/live-server.js
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+var path = require('path');
+var fs = require('fs');
+var assign = require('object-assign');
 var liveServer = require("./index");
 
 var opts = {
@@ -6,6 +9,12 @@ var opts = {
 	open: true,
 	logLevel: 2
 };
+
+var configPath = path.join(process.env.HOME, '.live-server.json');
+if (fs.existsSync(configPath)) {
+	var userConfig = fs.readFileSync(configPath, 'utf8');
+	assign(opts, JSON.parse(userConfig));
+}
 
 for (var i = process.argv.length-1; i >= 2; --i) {
 	var arg = process.argv[i];

--- a/package.json
+++ b/package.json
@@ -12,13 +12,14 @@
 	],
 	"author": "Tapio Vierros",
 	"dependencies": {
-		"connect": "2.x.x",
-		"send": "latest",
 		"colors": "latest",
-		"open": "latest",
-		"watchr": "2.3.x",
+		"connect": "2.x.x",
+		"event-stream": "latest",
 		"faye-websocket": "0.9.x",
-		"event-stream" : "latest"
+		"object-assign": "^2.0.0",
+		"open": "latest",
+		"send": "latest",
+		"watchr": "2.3.x"
 	},
 	"scripts": {
 		"test": "jshint *.js"


### PR DESCRIPTION
If the file `~/.live-server.json` exists, use its' contents as default options.

eg. I never want live-server to open my browser so I have 

```json
{
  "open": false
}
```

in my `~/.live-server.json`.