### PR TITLE
Add --ignore option

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,6 +107,7 @@ LiveServer.start = function(options) {
 	// Setup file watcher
 	watchr.watch({
 		path: root,
+		ignorePaths: options.ignore || false,
 		ignoreCommonPatterns: true,
 		ignoreHiddenFiles: true,
 		preferredMethods: [ 'watchFile', 'watch' ],

--- a/live-server.js
+++ b/live-server.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 var liveServer = require("./index");
+var path = require('path');
 
 var opts = {
 	port: process.env.PORT,
@@ -25,6 +26,16 @@ for (var i = process.argv.length-1; i >= 2; --i) {
 		opts.open = path;
 		process.argv.splice(i, 1);
 	}
+	else if (arg.indexOf("--ignore=") > -1) {
+		var cwd = process.cwd();
+		opts.ignore =
+			arg.substring(9).
+				split(",").
+				map(function (relativePath) {
+					return path.join(cwd, relativePath);
+				});
+		process.argv.splice(i, 1);
+	}
 	else if (arg == "--no-browser") {
 		opts.open = false;
 		process.argv.splice(i, 1);
@@ -32,7 +43,7 @@ for (var i = process.argv.length-1; i >= 2; --i) {
 		opts.logLevel = 0;
 		process.argv.splice(i, 1);
 	} else if (arg == "--help" || arg == "-h") {
-		console.log('Usage: live-server [-h|--help] [-q|--quiet] [--port=PORT] [--open=PATH] [--no-browser] [PATH]');
+		console.log('Usage: live-server [-h|--help] [-q|--quiet] [--port=PORT] [--open=PATH] [--ignore=PATH] [--no-browser] [PATH]');
 		process.exit();
 	}
 }


### PR DESCRIPTION
Allows watchr to ignore certain paths. My use-case is when using a template engine to build a site, I want live-server to reload when the template engine writes out new html files, not when the template files themselves have changed.

I apologise that the formatting looks bad on lines 31-36. I would like to suggest that it looks better switching to spaces, please see #41.