### PR TITLE
fix css refresh for chrome

### DIFF
--- a/injected.html
+++ b/injected.html
@@ -3,13 +3,16 @@
 	(function() {
 		function refreshCSS() {
 			var sheets = document.getElementsByTagName("link");
+			var head = document.getElementsByTagName("head")[0];
 			for (var i = 0; i < sheets.length; ++i) {
 				var elem = sheets[i];
+				head.removeChild(elem);
 				var rel = elem.rel;
 				if (elem.href && typeof rel != "string" || rel.length == 0 || rel.toLowerCase() == "stylesheet") {
 					var url = elem.href.replace(/(&|\?)_cacheOverride=\d+/, '');
 					elem.href = url + (url.indexOf('?') >= 0 ? '&' : '?') + '_cacheOverride=' + (new Date().valueOf());
 				}
+				head.appendChild(elem);
 			}
 		}
 		var protocol = window.location.protocol === 'http:' ? 'ws://' : 'wss://';


### PR DESCRIPTION
Chrome doesn't detect the href change in the `<link />` elements, but we can force detection by detaching `<link />` from the DOM, updating the href, and then re-attaching. No need for any crazy css.

```js
function refreshCSS() {
    var sheets = document.getElementsByTagName("link");
    var head = document.getElementsByTagName("head")[0]; 
    for (var i = 0; i < sheets.length; ++i) {
        var elem = sheets[i];
        head.removeChild(elem); // !impt
        var rel = elem.rel;
        if (elem.href && typeof rel != "string" || rel.length == 0 || rel.toLowerCase() == "stylesheet") {
            var url = elem.href.replace(/(&|\?)_cacheOverride=\d+/, '');
            elem.href = url + (url.indexOf('?') >= 0 ? '&' : '?') + '_cacheOverride=' + (new Date().valueOf());
        }
        head.appendChild(elem); // !impt
    }
}
```

Fixes issue https://github.com/tapio/live-server/issues/5