### PR TITLE
fixed css reload re-ordering issue

### DIFF
--- a/injected.html
+++ b/injected.html
@@ -2,7 +2,7 @@
 	// Code injected by live-server
 	(function() {
 		function refreshCSS() {
-			var sheets = document.getElementsByTagName("link");
+			var sheets = [].slice.call(document.getElementsByTagName("link"));
 			var head = document.getElementsByTagName("head")[0];
 			for (var i = 0; i < sheets.length; ++i) {
 				var elem = sheets[i];


### PR DESCRIPTION
> I merged this and it indeed seems to fix the issue. However, this patch reorders the link elements in the head. I'm not sure if it can lead to actual problems, but at the very least it is bad practice. Could you fix that?
> -- @tapio 

I confirmed the issue, and found the fix. (The `sheets` variable was an `HTMLCollection` which re-orders itself as the nodes were being removed/added. It should've been converted into an array.)

Fixes issue https://github.com/tapio/live-server/issues/5