### PR TITLE
Add --mount to serve files from alternate path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Command line parameters:
 * `--open=PATH` - launch browser to PATH instead of server root
 * `--ignore=PATH` - comma-separated string of paths to ignore
 * `--entry-file=PATH` - serve this file in place of missing files (useful for single page apps)
+* `--mount=ROUTE:PATH` - serve the paths contents under the defined route (multiple definitions possible)
 * `--wait=MILLISECONDS` - wait for all changes, before reloading
 * `--help | -h` - display terse usage hint and exit
 * `--version | -v` - display version and exit
@@ -72,6 +73,7 @@ var params = {
 	ignore: 'scss,my/templates', // comma-separated string for paths to ignore
 	file: "index.html", // When set, serve this file for every 404 (useful for single-page applications)
 	wait: 1000 // Waits for all changes, before reloading. Defaults to 0 sec.
+	mount: [['/components', './node_modules']] // Mount a directory to a route.
 };
 liveServer.start(params);
 ```

--- a/live-server.js
+++ b/live-server.js
@@ -7,6 +7,7 @@ var liveServer = require("./index");
 var opts = {
 	port: process.env.PORT,
 	open: true,
+	mount: [],
 	logLevel: 2
 };
 
@@ -59,6 +60,13 @@ for (var i = process.argv.length - 1; i >= 2; --i) {
 		opts.logLevel = 0;
 		process.argv.splice(i, 1);
 	}
+	else if (arg.indexOf("--mount=") > -1) {
+		// e.g. "--mount=/components:./node_modules" will be ['/components', '<process.cwd()>/node_modules']
+		var mountRule = arg.substring(8).split(":");
+		mountRule[1] = path.resolve(process.cwd(), mountRule[1]); 
+		opts.mount.push(mountRule);
+		process.argv.splice(i, 1);
+	}
 	else if (arg.indexOf("--wait=") > -1) {
 		var waitString = arg.substring(7);
 		var waitNumber = parseInt(waitString, 10);
@@ -73,7 +81,7 @@ for (var i = process.argv.length - 1; i >= 2; --i) {
 		process.exit();
 	}
 	else if (arg == "--help" || arg == "-h") {
-		console.log('Usage: live-server [-v|--version] [-h|--help] [-q|--quiet] [--port=PORT] [--host=HOST] [--open=PATH] [--no-browser] [--ignore=PATH] [--entry-file=PATH] [--wait=MILLISECONDS] [PATH]');
+		console.log('Usage: live-server [-v|--version] [-h|--help] [-q|--quiet] [--port=PORT] [--host=HOST] [--open=PATH] [--no-browser] [--ignore=PATH] [--entry-file=PATH] [--mount=ROUTE:PATH] [--wait=MILLISECONDS] [PATH]');
 		process.exit();
 	}
 }


### PR DESCRIPTION
Heya.

I think source tells more than words, so I implemented my proposal. Nevertheless some words. This PR allows to mount folders into the hosted web application. For me this is useful for 2 reasons:

1. I don't like to address artifacts under ../node_modules, as they should be hosted under /components in my target environment and I feel unwell to explicitly leave the source/root folder.
2. I like typescript or coffee script files to be transpiled into a separate build directory but they should be hosted at the location where the sources were.

With this PR I am able to start the live-server with
```
live-server --mount=/components:node_modules --mount=/:build source
```
Maybe nasty configuration, but simple. The `--mount=` indicates the configuration parameter, the `:` is used to separate the route from the folder.
It is also possible to configure it as node modules as an array of arrays:
```JavaScript
{
  mount: [['/components', 'node_modules'], ['/', 'build']]
}
```
The reason why I decided to use arrays instead of an object is, that it may be possible to define a route for multiple folders. Maybe there are better possibilities for this one, but I wanted to keep it simple unless I don't know if you even accept the idea.

The implementation is quite simple, I just reuse the existing staticServer implementation and just used `paths` instead of `path` for watchr.

BTW: Don't know how to describe that --mount can be used multiple times in the Usage example. Maybe it's not necessary at all.

Keep in mind, that this is just a proposal. I am not sure if it matches will all the paradigms and ideas of the module, especially regarding the simplicity. That's up to you to decide. ;)