### PR TITLE
Svg support

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,20 +56,23 @@ function staticServer(root) {
 		}
 
 		function inject(stream) {
-			if (doInject || doInjectSvg) {
+			if (doInject) {
 				// We need to modify the length given to browser
 				var len = INJECTED_CODE.length + res.getHeader('Content-Length');
 				res.setHeader('Content-Length', len);
 				var originalPipe = stream.pipe;
-				if(doInjectSvg) {
-					stream.pipe = function(res) {
-						originalPipe.call(stream, es.replace(new RegExp("</svg>", "i"), wrapToSvg(INJECTED_CODE) + "</svg>")).pipe(res);
-					};
-				} else {
-					stream.pipe = function(res) {
-						originalPipe.call(stream, es.replace(new RegExp("</body>", "i"), INJECTED_CODE + "</body>")).pipe(res);
-					};
-				}
+				stream.pipe = function(res) {
+					originalPipe.call(stream, es.replace(new RegExp("</body>", "i"), INJECTED_CODE + "</body>")).pipe(res);
+				};
+			} else if(doInjectSvg) {
+				// We need to modify the length given to browser
+				var WRAPPED_INJECTED_CODE = wrapToSvg(INJECTED_CODE);
+				var len = WRAPPED_INJECTED_CODE.length + res.getHeader('Content-Length');
+				res.setHeader('Content-Length', len);
+				var originalPipe = stream.pipe;
+				stream.pipe = function(res) {
+					originalPipe.call(stream, es.replace(/<\/svg>/i, WRAPPED_INJECTED_CODE + "</svg>")).pipe(res);
+				};
 			}
 		}
 		

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ function staticServer(root) {
 		var reqpath = url.parse(req.url).pathname;
 		var hasNoOrigin = !req.headers.origin;
 		var doInject = false;
+		var doInjectSvg = false;
 
 		function directory() {
 			var pathname = url.parse(req.originalUrl).pathname;
@@ -40,11 +41,12 @@ function staticServer(root) {
 
 		function file(filepath, stat) {
 			var x = path.extname(filepath).toLocaleLowerCase(),
-					possibleExtensions = ["", ".html", ".htm", ".xhtml", ".php"];
+					possibleExtensions = ["", ".html", ".htm", ".xhtml", ".php", ".svg"];
 			if (hasNoOrigin && (possibleExtensions.indexOf(x) > -1)) {
 				// TODO: Sync file read here is not nice, but we need to determine if the html should be injected or not
 				var contents = fs.readFileSync(filepath, "utf8");
-				doInject = contents.indexOf("</body>") > -1;
+				doInject = contents.indexOf("</body>") > -1
+				doInjectSvg = contents.indexOf("</svg>") > -1;
 			}
 		}
 
@@ -54,15 +56,27 @@ function staticServer(root) {
 		}
 
 		function inject(stream) {
-			if (doInject) {
+			if (doInject || doInjectSvg) {
 				// We need to modify the length given to browser
 				var len = INJECTED_CODE.length + res.getHeader('Content-Length');
 				res.setHeader('Content-Length', len);
 				var originalPipe = stream.pipe;
-				stream.pipe = function(res) {
-					originalPipe.call(stream, es.replace(new RegExp("</body>", "i"), INJECTED_CODE + "</body>")).pipe(res);
-				};
+				if(doInjectSvg) {
+					stream.pipe = function(res) {
+						originalPipe.call(stream, es.replace(new RegExp("</svg>", "i"), wrapToSvg(INJECTED_CODE) + "</svg>")).pipe(res);
+					};
+				} else {
+					stream.pipe = function(res) {
+						originalPipe.call(stream, es.replace(new RegExp("</body>", "i"), INJECTED_CODE + "</body>")).pipe(res);
+					};
+				}
 			}
+		}
+		
+		function wrapToSvg(injectioncode) {
+			return injectioncode
+				.replace(/^(<script)(>)/i, "$1 type=\"application/ecmascript\"$2<![CDATA[")
+				.replace(/(<\/script>)$/i, "]]>$1");
 		}
 
 		send(req, reqpath, { root: root })


### PR DESCRIPTION
This is a quick and dirty patch to support SVG files. I noticed that if I don't supply the path to `live-server` then some of the served file is missing. I assume it has something to do with the the HTTP Content-Length but it does not appear to be in any of the code I have touched.

Usage: `live-server open=pathToSvg.svg .` if current directory.

Note that this does **not** work: `live-server open=pathToSvg.svg` - no path to current directory.

This patch is too quick to have unit test ;)