### PR TITLE
Add an error message when a file cannot be injected

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,6 +54,11 @@ function staticServer(root) {
 						break;
 					}
 				}
+				if (injectTag === null) {
+					console.error("Refresh won't happen as no file was find to watch. ".red + 
+						"If you have html files, please check their syntax.");
+				}
+				
 			}
 		}
 


### PR DESCRIPTION
Hello, first I need to tell that I love your module. But I was surprise to see it not working for a file I wrote. Actually I made a mistake in my html syntax. And it would have saved me an hour is the module would have told me that I did something wrong.

So I add a little message when the http snippet cannot be injected.