### PR TITLE
check for process.env.IP as HOST address

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ var liveServer = require("live-server");
 
 var params = {
 	port: 8181, // Set the server port. Defaults to 8080.
-	host: "0.0.0.0", // Set the address to bind to. Defaults to 0.0.0.0.
+	host: "0.0.0.0", // Set the address to bind to. Defaults to 0.0.0.0 or process.env.IP.
 	root: "/public", // Set root directory that's being server. Defaults to cwd.
 	open: false, // When false, it won't load your browser by default.
 	ignore: 'scss,my/templates', // comma-separated string for paths to ignore

--- a/live-server.js
+++ b/live-server.js
@@ -5,6 +5,7 @@ var assign = require('object-assign');
 var liveServer = require("./index");
 
 var opts = {
+	host: process.env.IP,
 	port: process.env.PORT,
 	open: true,
 	mount: [],

--- a/package.json
+++ b/package.json
@@ -1,61 +1,63 @@
 {
-	"name": "live-server",
-	"version": "0.9.2",
-	"description": "simple development http server with live reload capability",
-	"keywords": [
-		"front-end",
-		"development",
-		"tool",
-		"server",
-		"http",
-		"cli"
-	],
-	"author": "Tapio Vierros",
-	"dependencies": {
-		"colors": "latest",
-		"connect": "3.4.x",
-		"serve-index": "^1.7.2",
-		"morgan": "^1.6.1",
-		"event-stream": "latest",
-		"faye-websocket": "0.10.x",
-		"object-assign": "latest",
-		"opn": "latest",
-		"send": "latest",
-		"watchr": "2.3.x",
-		"http-auth": "2.2.x"
-	},
-	"devDependencies": {
-		"mocha": "^2.3.3",
-		"supertest": "^1.0.1"
-	},
-	"scripts": {
-		"lint": "jshint *.js; eslint *.js",
-		"test": "npm run lint && mocha test"
-	},
-	"bin": {
-		"live-server": "./live-server.js"
-	},
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/tapio/live-server.git"
-	},
-	"engines": {
-		"node": ">=0.10.0"
-	},
-	"preferGlobal": true,
-	"license": "MIT",
-	"eslintConfig": {
-		"env": {
-			"node": true
-		},
-		"rules": {
-			"quotes": 0,
-			"curly": 0,
-			"strict": 0,
-			"no-process-exit": 0,
-			"eqeqeq": 1,
-			"no-unused-vars": 1,
-			"no-shadow": 1
-		}
-	}
+  "name": "live-server",
+  "version": "0.9.2",
+  "description": "simple development http server with live reload capability",
+  "keywords": [
+    "front-end",
+    "development",
+    "tool",
+    "server",
+    "http",
+    "cli"
+  ],
+  "author": "Tapio Vierros",
+  "dependencies": {
+    "colors": "latest",
+    "connect": "3.4.x",
+    "serve-index": "^1.7.2",
+    "morgan": "^1.6.1",
+    "event-stream": "latest",
+    "faye-websocket": "0.10.x",
+    "object-assign": "latest",
+    "opn": "latest",
+    "send": "latest",
+    "watchr": "2.3.x",
+    "http-auth": "2.2.x"
+  },
+  "devDependencies": {
+    "eslint": "^2.2.0",
+    "jshint": "^2.9.1",
+    "mocha": "^2.3.3",
+    "supertest": "^1.0.1"
+  },
+  "scripts": {
+    "lint": "jshint *.js; eslint *.js",
+    "test": "npm run lint && mocha test"
+  },
+  "bin": {
+    "live-server": "./live-server.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tapio/live-server.git"
+  },
+  "engines": {
+    "node": ">=0.10.0"
+  },
+  "preferGlobal": true,
+  "license": "MIT",
+  "eslintConfig": {
+    "env": {
+      "node": true
+    },
+    "rules": {
+      "quotes": 0,
+      "curly": 0,
+      "strict": 0,
+      "no-process-exit": 0,
+      "eqeqeq": 1,
+      "no-unused-vars": 1,
+      "no-shadow": 1
+    }
+  }
 }


### PR DESCRIPTION
This should fix #95 with the caveat that I was wrong about cloud9. The nodejs container in cloud9 has process.env.IP set to 0.0.0.0 by default so this patch is basically not *really* tested.

Unfortunately, I can't test the patch on neither heroku or azure at the moment. So be careful about applying this before you have done your own testing.

*All tests pass*

Sorry about the whitespace format in `package.json`. @npm did it when I added `eslint` and `jshint` via `npm i --save-dev eslint jshint`. But I hope that the format is now npm compliant ;)
`npm -v 2.14.4`