### PR TITLE
Look up settings file from cwd

### DIFF
--- a/live-server.js
+++ b/live-server.js
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 var path = require('path');
 var fs = require('fs');
+var searchup = require("searchup");
+var stripJsonComments = require("strip-json-comments")
 var assign = require('object-assign');
 var liveServer = require("./index");
 
@@ -11,10 +13,10 @@ var opts = {
 	logLevel: 2
 };
 
-var homeDir = process.env[(process.platform == 'win32') ? 'USERPROFILE' : 'HOME'];
-var configPath = path.join(homeDir, '.live-server.json');
+var configPath = searchup.searchSync('.live-server.json');
 if (fs.existsSync(configPath)) {
 	var userConfig = fs.readFileSync(configPath, 'utf8');
+	userConfig = stripJsonComments(userConfig);
 	assign(opts, JSON.parse(userConfig));
 }
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
 		"opn": "latest",
 		"send": "latest",
 		"watchr": "2.3.x",
-		"http-auth": "2.2.x"
+		"http-auth": "2.2.x",
+		"searchup": "0.0.1",
+		"strip-json-comments": "2.0.1"
 	},
 	"devDependencies": {
 		"mocha": "^2.3.3",


### PR DESCRIPTION
- Added functionality to lookup `.live-server.json` file starting from the cwd.
- Added ability to put comments into the config file.

~~Sorry for `package.json`, npm had reformatted it when I~~ added dependencies, which are:

`searchup` - to actually lookup fs for provided filename until root folder or user home directory.
`strip-json-comments` - to strip up comments from json file.

Also dependencies added with --save-exact flag

This could be nice addition to share dev settings among the team, or to have group settings for several projects.


+UPD: manually edited `package.json` to include dependencies to and avoid indents auto-reformatting.