### PR TITLE
Fix for when ignorePattern specified in .live-server.json

### DIFF
--- a/live-server.js
+++ b/live-server.js
@@ -16,6 +16,7 @@ var configPath = path.join(homeDir, '.live-server.json');
 if (fs.existsSync(configPath)) {
 	var userConfig = fs.readFileSync(configPath, 'utf8');
 	assign(opts, JSON.parse(userConfig));
+	if (opts.ignorePattern) opts.ignorePattern = new RegExp(opts.ignorePattern);
 }
 
 for (var i = process.argv.length - 1; i >= 2; --i) {


### PR DESCRIPTION
opts.ignoreCustomPatterns was a string when the ignorePattern flag was set in .live-server.json and needed to be made a RegExp object.