### PR TITLE
setting the proxy-middleware preserveHost to true

### DIFF
--- a/index.js
+++ b/index.js
@@ -184,6 +184,7 @@ LiveServer.start = function(options) {
 	proxy.forEach(function(proxyRule) {
 		var proxyOpts = url.parse(proxyRule[1]);
 		proxyOpts.via = true;
+		proxyOpts.preserveHost = true;
 		app.use(proxyRule[0], require('proxy-middleware')(proxyOpts));
 		if (LiveServer.logLevel >= 1)
 			console.log('Mapping %s to "%s"', proxyRule[0], proxyRule[1]);


### PR DESCRIPTION
I think having the live-server http host header preserved when proxying is a reasonable default. I can't think of any scenarios where this would hurt anybody and there are (admittedly obscure) scenarios where the original host needs to be inspected by the back-end. I'm happy to make this a configurable entity but I think that might be a little bloated e.g. --proxy=[ROUTE:URL:PRESERVE]