### PR TITLE
Added middleware logic, readme, and tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ var params = {
 	file: "index.html", // When set, serve this file for every 404 (useful for single-page applications)
 	wait: 1000, // Waits for all changes, before reloading. Defaults to 0 sec.
 	mount: [['/components', './node_modules']], // Mount a directory to a route.
-	logLevel: 2 // 0 = errors only, 1 = some, 2 = lots
+	logLevel: 2, // 0 = errors only, 1 = some, 2 = lots
+	middleware: [function(req, res, next) { next(); }] // Takes an array of Connect-compatible middleware that are injected into the server middleware stack
 };
 liveServer.start(params);
 ```
@@ -129,6 +130,7 @@ Version history
 
 * master (unreleased)
 	- Proxy support (@pavel)
+	- Middleware support (@achandrasekar)
 * v1.0.0
 	- HTTPS support (@pavel)
 	- HTTP Basic authentication support (@hey-johnnypark)

--- a/index.js
+++ b/index.js
@@ -133,6 +133,7 @@ function entryPoint(staticHandler, file) {
  * @param file {string} Path to the entry point file
  * @param wait {number} Server will wait for all changes, before reloading
  * @param htpasswd {string} Path to htpasswd file to enable HTTP Basic authentication
+ * @param middleware {array} Append middleware to stack, e.g. [function(req, res, next) { next(); }].
  */
 LiveServer.start = function(options) {
 	options = options || {};

--- a/index.js
+++ b/index.js
@@ -154,6 +154,7 @@ LiveServer.start = function(options) {
 	var cors = options.cors || false;
 	var https = options.https || null;
 	var proxy = options.proxy || [];
+	var middleware = options.middleware || [];
 
 	// Setup a web server
 	var app = connect();
@@ -193,6 +194,9 @@ LiveServer.start = function(options) {
 		.use(serveIndex(root, { icons: true }));
 	if (LiveServer.logLevel >= 2)
 		app.use(logger('dev'));
+
+	// Add middleware
+	middleware.map(app.use.bind(app));
 
 	var server, protocol;
 	if (https !== null) {

--- a/index.js
+++ b/index.js
@@ -160,6 +160,9 @@ LiveServer.start = function(options) {
 	// Setup a web server
 	var app = connect();
 
+	// Add middleware
+	middleware.map(app.use.bind(app));
+
 	// Use http-auth if configured
 	if (htpasswd !== null) {
 		var auth = require('http-auth');
@@ -195,9 +198,6 @@ LiveServer.start = function(options) {
 		.use(serveIndex(root, { icons: true }));
 	if (LiveServer.logLevel >= 2)
 		app.use(logger('dev'));
-
-	// Add middleware
-	middleware.map(app.use.bind(app));
 
 	var server, protocol;
 	if (https !== null) {

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -1,0 +1,26 @@
+var response = 'middleware added';
+var path = require('path');
+var liveServer = require('..').start({
+	root: path.join(__dirname, 'data'),
+	port: 0,
+	open: false,
+	middleware: [
+		function middleware() {
+			return response;
+		}
+	]
+});
+
+describe('middleware tests', function() {
+	it('should add middleware to stack', function(done) {
+		var middlewareStack = liveServer._events.request.stack;
+		var middlewareResponse = middlewareStack[middlewareStack.length - 1].handle();
+
+		if (middlewareResponse === response) {
+			done();
+		} else {
+			throw new Error('middleware missing');
+		}
+
+	});
+});

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -1,26 +1,21 @@
-var response = 'middleware added';
+var request = require('supertest');
 var path = require('path');
 var liveServer = require('..').start({
 	root: path.join(__dirname, 'data'),
 	port: 0,
 	open: false,
 	middleware: [
-		function middleware() {
-			return response;
+		function setStatus(req, res, next) {
+			res.statusCode = 201;
+			next();
 		}
 	]
 });
 
 describe('middleware tests', function() {
 	it('should add middleware to stack', function(done) {
-		var middlewareStack = liveServer._events.request.stack;
-		var middlewareResponse = middlewareStack[middlewareStack.length - 1].handle();
-
-		if (middlewareResponse === response) {
-			done();
-		} else {
-			throw new Error('middleware missing');
-		}
-
+		request(liveServer)
+			.get('/')
+			.expect(201, done);
 	});
 });


### PR DESCRIPTION
This PR gives the ability to add middleware to the connect server by taking an array of connect-compatible middleware in the options and appending them to the stack.

```javascript
var liveServer = require("live-server");

var params = {
	port: 8181, // Set the server port. Defaults to 8080.
	host: "0.0.0.0", // Set the address to bind to. Defaults to 0.0.0.0 or process.env.IP.
	root: "/public", // Set root directory that's being server. Defaults to cwd.
	open: false, // When false, it won't load your browser by default.
	ignore: 'scss,my/templates', // comma-separated string for paths to ignore
	file: "index.html", // When set, serve this file for every 404 (useful for single-page applications)
	wait: 1000, // Waits for all changes, before reloading. Defaults to 0 sec.
	mount: [['/components', './node_modules']], // Mount a directory to a route.
	logLevel: 2, // 0 = errors only, 1 = some, 2 = lots
	middleware: [function(req, res, next) { next(); }] // Takes an array of Connect-compatible middleware that are injected into the server middleware stack
};
liveServer.start(params);
```