### PR TITLE
Closes #129, #133

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Command line parameters:
 * `--no-browser` - suppress automatic web browser launching
 * `--browser=BROWSER` - specify browser to use instead of system default
 * `--quiet | -q` - suppress logging
-* `--verbose | -vv` - more logging (logs all requests, etc.)
+* `--verbose | -V` - more logging (logs all requests, etc.)
 * `--open=PATH` - launch browser to PATH instead of server root
 * `--watch=PATH` - comma-separated string of paths to exclusively watch for changes (default: watch everything)
 * `--ignore=PATH` - comma-separated string of paths to ignore

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Command line parameters:
 * `--host=ADDRESS` - select host address to bind to, default: IP env var or 0.0.0.0 ("any address")
 * `--no-browser` - suppress automatic web browser launching
 * `--browser=BROWSER` - specify browser to use instead of system default
-* `--quiet` - suppress logging
+* `--quiet | -q` - suppress logging
+* `--verbose | -vv` - more logging (logs all requests, etc.)
 * `--open=PATH` - launch browser to PATH instead of server root
 * `--watch=PATH` - comma-separated string of paths to exclusively watch for changes (default: watch everything)
 * `--ignore=PATH` - comma-separated string of paths to ignore

--- a/index.js
+++ b/index.js
@@ -202,7 +202,10 @@ LiveServer.start = function(options) {
 
 	var server, protocol;
 	if (https !== null) {
-		var httpsConfig = require(path.resolve(process.cwd(), https));
+		var httpsConfig = https;
+		if (typeof https === "string") {
+			httpsConfig = require(path.resolve(process.cwd(), https));
+		}
 		server = require("https").createServer(httpsConfig, app);
 		protocol = "https";
 	} else {

--- a/index.js
+++ b/index.js
@@ -160,6 +160,15 @@ LiveServer.start = function(options) {
 	// Setup a web server
 	var app = connect();
 
+	// Add logger. Level 2 logs only errors
+	if (LiveServer.logLevel == 2) {
+		app.use(logger('dev', {
+			skip: function (req, res) { return res.statusCode < 400; }
+		}));
+	// Level 2 or above logs all requests
+	} else if (LiveServer.logLevel > 2) {
+		app.use(logger('dev'));
+	}
 	// Add middleware
 	middleware.map(app.use.bind(app));
 
@@ -197,8 +206,6 @@ LiveServer.start = function(options) {
 	app.use(staticServerHandler) // Custom static server
 		.use(entryPoint(staticServerHandler, file))
 		.use(serveIndex(root, { icons: true }));
-	if (LiveServer.logLevel >= 2)
-		app.use(logger('dev'));
 
 	var server, protocol;
 	if (https !== null) {

--- a/live-server.js
+++ b/live-server.js
@@ -80,7 +80,7 @@ for (var i = process.argv.length - 1; i >= 2; --i) {
 		opts.logLevel = 0;
 		process.argv.splice(i, 1);
 	}
-	else if (arg === "--verbose" || arg === "-vv") {
+	else if (arg === "--verbose" || arg === "-V") {
 		opts.logLevel = 3;
 		process.argv.splice(i, 1);
 	}

--- a/live-server.js
+++ b/live-server.js
@@ -80,6 +80,10 @@ for (var i = process.argv.length - 1; i >= 2; --i) {
 		opts.logLevel = 0;
 		process.argv.splice(i, 1);
 	}
+	else if (arg === "--verbose" || arg === "-vv") {
+		opts.logLevel = 3;
+		process.argv.splice(i, 1);
+	}
 	else if (arg.indexOf("--mount=") > -1) {
 		// e.g. "--mount=/components:./node_modules" will be ['/components', '<process.cwd()>/node_modules']
 		var mountRule = arg.substring(8).split(":");

--- a/test/https.js
+++ b/test/https.js
@@ -1,15 +1,9 @@
 var request = require('supertest');
 var path = require('path');
-var liveServer = require('..').start({
-	root: path.join(__dirname, 'data'),
-	port: 0,
-	open: false,
-	https: path.join(__dirname, 'conf/https.conf.js')
-});
 // accept self-signed certificates
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
 
-describe('https tests', function() {
+function tests(liveServer) {
 	it('should reply with a correct index file', function(done) {
 		request(liveServer)
 			.get('/index.html')
@@ -23,6 +17,32 @@ describe('https tests', function() {
 			.expect('Content-Type', 'text/html; charset=UTF-8')
 			.expect(200, done);
 	});
+}
+
+describe('https tests with external module', function() {
+	var opts = {
+		root: path.join(__dirname, 'data'),
+		port: 0,
+		open: false,
+		https: path.join(__dirname, 'conf/https.conf.js')
+	};
+	var liveServer = require("..").start(opts);
+	tests(liveServer);
+	after(function () {
+		liveServer.close()
+	});
 });
 
-
+describe('https tests with object', function() {
+	var opts = {
+		root: path.join(__dirname, 'data'),
+		port: 0,
+		open: false,
+		https: require(path.join(__dirname, 'conf/https.conf.js'))
+	};
+	var liveServer = require("..").start(opts);
+	tests(liveServer);
+	after(function () {
+		liveServer.close()
+	});
+});


### PR DESCRIPTION
- Fix for #129  
  - Use `https` param as external module path, only if `https` param is `string`.  
     Otherwise consider `https` param a parameter for `https.createServer`.
  - Added tests.
- Fix for #133  
  - Moved `morgan` HTTP(S) request logger to the very top of the middleware chain.  
     When `logLevel === 3` logs all requests. `logLevel === 2` logs only HTTP errors.
  - Added `--verbose` (short alias `-vv`), which sets `logLevel` to `3`.
  - Added short alias of `-q` (`--quiet`) to the `README.md`, as it is handled by the code.