### PR TITLE
Issue 121

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Command line parameters:
 * `--no-browser` - suppress automatic web browser launching
 * `--browser=BROWSER` - specify browser to use instead of system default
 * `--quiet | -q` - suppress logging
-* `--verbose | -V` - more logging (logs all requests, etc.)
+* `--verbose | -V` - more logging (logs all requests, shows all listening IPv4 interfaces, etc.)
 * `--open=PATH` - launch browser to PATH instead of server root
 * `--watch=PATH` - comma-separated string of paths to exclusively watch for changes (default: watch everything)
 * `--ignore=PATH` - comma-separated string of paths to ignore

--- a/index.js
+++ b/index.js
@@ -247,7 +247,7 @@ LiveServer.start = function(options) {
 		var openURL = protocol + '://' + openHost + ':' + address.port;
 
 		var serveURLs = [ serveURL ];
-		if (address.address === "0.0.0.0") {
+		if (LiveServer.logLevel > 2 && address.address === "0.0.0.0") {
 			var ifaces = os.networkInterfaces();
 			serveURLs = Object.keys(ifaces)
 				.map(function (iface) {
@@ -270,7 +270,11 @@ LiveServer.start = function(options) {
 		// Output
 		if (LiveServer.logLevel >= 1) {
 			if (serveURL === openURL)
-				console.log(("Serving \"%s\" at\n\t%s").green, root, serveURLs.join("\n\t"));
+				if (serveURLs.length === 1) {
+					console.log(("Serving \"%s\" at %s").green, root, serveURLs[0]);
+				} else {
+					console.log(("Serving \"%s\" at\n\t%s").green, root, serveURLs.join("\n\t"));
+				}
 			else
 				console.log(("Serving \"%s\" at %s (%s)").green, root, openURL, serveURL);
 		}

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ var fs = require('fs'),
 	send = require('send'),
 	open = require('opn'),
 	es = require("event-stream"),
+	os = require('os'),
 	watchr = require('watchr');
 require('colors');
 
@@ -245,10 +246,31 @@ LiveServer.start = function(options) {
 		var serveURL = protocol + '://' + serveHost + ':' + address.port;
 		var openURL = protocol + '://' + openHost + ':' + address.port;
 
+		var serveURLs = [ serveURL ];
+		if (address.address === "0.0.0.0") {
+			var ifaces = os.networkInterfaces();
+			serveURLs = Object.keys(ifaces)
+				.map(function (iface) {
+					return ifaces[iface];
+				})
+				// flatten address data, use only IPv4
+				.reduce(function (data, addresses) {
+					addresses.filter(function (address) {
+						return address.family === "IPv4";
+					}).forEach(function (address) {
+						data.push(address);
+					});
+					return data;
+				}, [])
+				.map(function (addr) {
+					return protocol + "://" + addr.address + ":" + address.port;
+				});
+		}
+
 		// Output
 		if (LiveServer.logLevel >= 1) {
 			if (serveURL === openURL)
-				console.log(("Serving \"%s\" at %s").green, root, serveURL);
+				console.log(("Serving \"%s\" at\n\t%s").green, root, serveURLs.join("\n\t"));
 			else
 				console.log(("Serving \"%s\" at %s (%s)").green, root, openURL, serveURL);
 		}


### PR DESCRIPTION
- Solution for #121
  - to active a user has to use `--verbose`/`-V` flag and listen on "non-localhost" interfaces.  
    (e.g. `live-server -V public/`)
  - updated docs to reflect activation upon `--verbose`/`-V` flag.