### PR TITLE
fix misspelling of Usage from node section

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ var liveServer = require("live-server");
 var params = {
 	port: 8181, // Set the server port. Defaults to 8080.
 	host: "0.0.0.0", // Set the address to bind to. Defaults to 0.0.0.0 or process.env.IP.
-	root: "/public", // Set root directory that's being server. Defaults to cwd.
+	root: "/public", // Set root directory that's being served. Defaults to cwd.
 	open: false, // When false, it won't load your browser by default.
 	ignore: 'scss,my/templates', // comma-separated string for paths to ignore
 	file: "index.html", // When set, serve this file for every 404 (useful for single-page applications)


### PR DESCRIPTION
This fixes the misspelling described on ticket #140