### PR TITLE
SPA setting: ignore files with extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Command line parameters:
 * `--entry-file=PATH` - serve this file (server root relative) in place of missing files (useful for single page apps)
 * `--mount=ROUTE:PATH` - serve the paths contents under the defined route (multiple definitions possible)
 * `--spa` - translate requests from /abc to /#/abc (handy for Single Page Apps)
+* `--spa-ignore-assets` - when `--spa` is passed, this option stops the server intercepting requests for any assets (CSS, JS and so on)
 * `--wait=MILLISECONDS` - wait for all changes, before reloading
 * `--htpasswd=PATH` - Enables http-auth expecting htpasswd file located at PATH
 * `--cors` - Enables CORS for any origin (reflects request origin, requests with credentials are supported)

--- a/index.js
+++ b/index.js
@@ -46,10 +46,14 @@ function staticServer(root, spa) {
 
 		// Single Page App - redirect handler
 		if (spa && req.url !== '/') {
-			var route = req.url;
-			req.url = '/';
-			res.statusCode = 302;
-			res.setHeader('Location', req.url + '#' + route);
+			var ext = path.extname(req.url);
+			// when there is no extension, path.extname === ''
+			if (ext === '') {
+				var route = req.url;
+				req.url = '/';
+				res.statusCode = 302;
+				res.setHeader('Location', req.url + '#' + route);
+			}
 		}
 
 		function directory() {

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ function escape(html){
 }
 
 // Based on connect.static(), but streamlined and with added code injecter
-function staticServer(root, spa) {
+function staticServer(root, spa, spaIgnoreAssets) {
 	var isFile = false;
 	try { // For supporting mounting files instead of just directories
 		isFile = fs.statSync(root).isFile();
@@ -47,12 +47,14 @@ function staticServer(root, spa) {
 		// Single Page App - redirect handler
 		if (spa && req.url !== '/') {
 			var ext = path.extname(req.url);
-			// when there is no extension, path.extname === ''
-			if (ext === '') {
-				var route = req.url;
-				req.url = '/';
-				res.statusCode = 302;
-				res.setHeader('Location', req.url + '#' + route);
+			if (spaIgnoreAssets) {
+				// when there is no extension, path.extname === ''
+				if (ext === '') {
+					var route = req.url;
+					req.url = '/';
+					res.statusCode = 302;
+					res.setHeader('Location', req.url + '#' + route);
+				}
 			}
 		}
 
@@ -150,9 +152,10 @@ LiveServer.start = function(options) {
 	var openPath = (options.open === undefined || options.open === true) ?
 		"" : ((options.open === null || options.open === false) ? null : options.open);
 	var spa = options.spa || false;
+	var spaIgnoreAssets = options.spaIgnoreAssets || false;
 	if (options.noBrowser) openPath = null; // Backwards compatibility with 0.7.0
 	var file = options.file;
-	var staticServerHandler = staticServer(root, spa);
+	var staticServerHandler = staticServer(root, spa, spaIgnoreAssets);
 	var wait = options.wait || 0;
 	var browser = options.browser || null;
 	var htpasswd = options.htpasswd || null;

--- a/index.js
+++ b/index.js
@@ -47,14 +47,15 @@ function staticServer(root, spa, spaIgnoreAssets) {
 		// Single Page App - redirect handler
 		if (spa && req.url !== '/') {
 			var ext = path.extname(req.url);
-			if (spaIgnoreAssets) {
-				// when there is no extension, path.extname === ''
-				if (ext === '') {
-					var route = req.url;
-					req.url = '/';
-					res.statusCode = 302;
-					res.setHeader('Location', req.url + '#' + route);
-				}
+			var shouldRewriteRequest = (spaIgnoreAssets === true && ext === '') ||
+				(typeof spaIgnoreAssets === 'function' &&
+					spaIgnoreAssets(req) === false);
+
+			if (shouldRewriteRequest) {
+				var route = req.url;
+				req.url = '/';
+				res.statusCode = 302;
+				res.setHeader('Location', req.url + '#' + route);
 			}
 		}
 

--- a/live-server.js
+++ b/live-server.js
@@ -76,6 +76,10 @@ for (var i = process.argv.length - 1; i >= 2; --i) {
 		opts.spa = true;
 		process.argv.splice(i, 1);
 	}
+	else if (arg === '--spa-ignore-assets') {
+		opts.spaIgnoreAssets = true;
+		process.argv.splice(i, 1);
+	}
 	else if (arg === "--quiet" || arg === "-q") {
 		opts.logLevel = 0;
 		process.argv.splice(i, 1);
@@ -123,7 +127,7 @@ for (var i = process.argv.length - 1; i >= 2; --i) {
 		process.argv.splice(i, 1);
 	}
 	else if (arg === "--help" || arg === "-h") {
-		console.log('Usage: live-server [-v|--version] [-h|--help] [-q|--quiet] [--port=PORT] [--host=HOST] [--open=PATH] [--no-browser] [--browser=BROWSER] [--ignore=PATH] [--ignorePattern=RGXP] [--entry-file=PATH] [--spa] [--mount=ROUTE:PATH] [--wait=MILLISECONDS] [--htpasswd=PATH] [--cors] [--https=PATH] [--proxy=PATH] [PATH]');
+		console.log('Usage: live-server [-v|--version] [-h|--help] [-q|--quiet] [--port=PORT] [--host=HOST] [--open=PATH] [--no-browser] [--browser=BROWSER] [--ignore=PATH] [--ignorePattern=RGXP] [--entry-file=PATH] [--spa] [--spa-ignore-assets] [--mount=ROUTE:PATH] [--wait=MILLISECONDS] [--htpasswd=PATH] [--cors] [--https=PATH] [--proxy=PATH] [PATH]');
 		process.exit();
 	}
 	else if (arg === "--test") {

--- a/test/spa.js
+++ b/test/spa.js
@@ -1,0 +1,30 @@
+var request = require('supertest');
+var path = require('path');
+var liveServer = require('..').start({
+	root: path.join(__dirname, "data"),
+	port: 0,
+	open: false,
+	spa: true
+});
+
+describe('spa tests', function() {
+	describe('when the URL has a file ext', function() {
+		it('does not mutate the request', function(done) {
+			request(liveServer)
+				.get('/style.css')
+				.expect(/color: red/i)
+				.expect(200, done);
+		});
+	});
+
+	describe('when the URL does not have a file ext', function() {
+		it('does mutate the request', function(done) {
+			request(liveServer)
+				.get('/123')
+				.expect('Location', '/#/123')
+				.expect(302, done);
+		});
+	});
+});
+
+

--- a/test/spa.js
+++ b/test/spa.js
@@ -1,26 +1,66 @@
 var request = require('supertest');
 var path = require('path');
-var liveServer = require('..').start({
-	root: path.join(__dirname, "data"),
-	port: 0,
-	open: false,
-	spa: true,
-	spaIgnoreAssets: true
-});
+var LiveServer = require('..');
+
+var liveServer;
 
 describe('spa tests', function() {
+	afterEach(function() {
+		LiveServer.shutdown();
+	});
+
 	describe('spaIgnoreAssets', function() {
-		describe('when the URL has a file ext', function() {
-			it('does not mutate the request', function(done) {
+		describe('when spaIgnoreAssets is set to true', function() {
+			beforeEach(function() {
+				liveServer = LiveServer.start({
+					root: path.join(__dirname, "data"),
+					port: 0,
+					open: false,
+					spa: true,
+					spaIgnoreAssets: true
+				});
+			});
+
+			describe('when the URL has a file ext', function() {
+				it('does not mutate the request', function(done) {
+					request(liveServer)
+						.get('/style.css')
+						.expect(/color: red/i)
+						.expect(200, done);
+				});
+			});
+
+			describe('when the URL does not have a file ext', function() {
+				it('does mutate the request', function(done) {
+					request(liveServer)
+						.get('/123')
+						.expect('Location', '/#/123')
+						.expect(302, done);
+				});
+			});
+		});
+
+		describe('when spaIgnoreAssets is a function', function() {
+			beforeEach(function() {
+				liveServer = LiveServer.start({
+					root: path.join(__dirname, "data"),
+					port: 0,
+					open: false,
+					spa: true,
+					spaIgnoreAssets: function(req) {
+						return req.url.indexOf('style.css') > -1;
+					}
+				});
+			});
+
+			it('does not mutate the request when the fn returns true', function(done) {
 				request(liveServer)
 					.get('/style.css')
 					.expect(/color: red/i)
 					.expect(200, done);
 			});
-		});
 
-		describe('when the URL does not have a file ext', function() {
-			it('does mutate the request', function(done) {
+			it('does mutate when the request returns false', function(done) {
 				request(liveServer)
 					.get('/123')
 					.expect('Location', '/#/123')

--- a/test/spa.js
+++ b/test/spa.js
@@ -4,25 +4,28 @@ var liveServer = require('..').start({
 	root: path.join(__dirname, "data"),
 	port: 0,
 	open: false,
-	spa: true
+	spa: true,
+	spaIgnoreAssets: true
 });
 
 describe('spa tests', function() {
-	describe('when the URL has a file ext', function() {
-		it('does not mutate the request', function(done) {
-			request(liveServer)
-				.get('/style.css')
-				.expect(/color: red/i)
-				.expect(200, done);
+	describe('spaIgnoreAssets', function() {
+		describe('when the URL has a file ext', function() {
+			it('does not mutate the request', function(done) {
+				request(liveServer)
+					.get('/style.css')
+					.expect(/color: red/i)
+					.expect(200, done);
+			});
 		});
-	});
 
-	describe('when the URL does not have a file ext', function() {
-		it('does mutate the request', function(done) {
-			request(liveServer)
-				.get('/123')
-				.expect('Location', '/#/123')
-				.expect(302, done);
+		describe('when the URL does not have a file ext', function() {
+			it('does mutate the request', function(done) {
+				request(liveServer)
+					.get('/123')
+					.expect('Location', '/#/123')
+					.expect(302, done);
+			});
 		});
 	});
 });


### PR DESCRIPTION
When running our app we do want requests like `/123/` to be converted to
`/#/123`, however things like `/style.css` or `/foo.png` should be
ignored. This commit changes the behaviour for the spa setting so it
only applies to requests without an extension.

This is a breaking change - I did also think if you were not so keen on this we could introduce a new configuration setting / CLI flag?