### PR TITLE
Speed improvement. Closes #137

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,10 @@ When implementing a new feature or a bugfix, consider these points:
 * Am I introducing unnecessary dependencies when the same thing could easily be done using normal JavaScript / node.js features?
 * Does the naming (e.g. command line parameters) make sense and uses same style as other similar ones?
 * Does my code adhere to the project's coding style (observable from surrounding code)?
+* Can backwards compatibility be preserved?
 
 A few guiding principles: keep the app simple and small, focusing on what it's meant to provide: live reloading development web server. Avoid extra dependencies and the need to do configuration when possible and it makes sense. Minimize bloat.
 
-**Run `npm test` to check that you are not introducing new bugs or style issues!**
+**New features should come with test cases!**
 
+**Run `npm test` to check that you are not introducing new bugs or style issues!**

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Command line parameters:
 * `--open=PATH` - launch browser to PATH instead of server root
 * `--watch=PATH` - comma-separated string of paths to exclusively watch for changes (default: watch everything)
 * `--ignore=PATH` - comma-separated string of paths to ignore ([anymatch](https://github.com/es128/anymatch)-compatible definition)
+* `--ignorePattern=RGXP` - Regular expression of files to ignore (ie `.*\.jade`) (**DEPRECATED** in favor of `--ignore`)
 * `--entry-file=PATH` - serve this file (server root relative) in place of missing files (useful for single page apps)
 * `--mount=ROUTE:PATH` - serve the paths contents under the defined route (multiple definitions possible)
 * `--spa` - translate requests from /abc to /#/abc (handy for Single Page Apps)

--- a/README.md
+++ b/README.md
@@ -113,8 +113,12 @@ If using the node API, you can also directly pass a configuration object instead
 Troubleshooting
 ---------------
 
-Open your browser's console: there should be a message at the top stating that live reload is enabled. Note that you will need a browser that supports WebSockets. If there are errors, deal with them. If it's still not working, [file an issue](https://github.com/tapio/live-server/issues).
-
+* No reload on changes
+	* Open your browser's console: there should be a message at the top stating that live reload is enabled. Note that you will need a browser that supports WebSockets. If there are errors, deal with them. If it's still not working, [file an issue](https://github.com/tapio/live-server/issues).
+* Error: watch <PATH> ENOSPC
+	* See [this suggested solution](http://stackoverflow.com/questions/22475849/node-js-error-enospc/32600959#32600959).
+* Reload works but changes are missing or outdated
+	* Try using `--wait=MS` option. Where `MS` is time in milliseconds to wait before issuing a reload.
 
 How it works
 ------------

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Command line parameters:
 * `--no-browser` - suppress automatic web browser launching
 * `--browser=BROWSER` - specify browser to use instead of system default
 * `--quiet | -q` - suppress logging
-* `--verbose | -V` - more logging (logs all requests, etc.)
+* `--verbose | -V` - more logging (logs all requests, shows all listening IPv4 interfaces, etc.)
 * `--open=PATH` - launch browser to PATH instead of server root
 * `--watch=PATH` - comma-separated string of paths to exclusively watch for changes (default: watch everything)
 * `--ignore=PATH` - comma-separated string of paths to ignore ([anymatch](https://github.com/es128/anymatch)-compatible definition)

--- a/README.md
+++ b/README.md
@@ -136,7 +136,8 @@ Version history
 ---------------
 
 * master (unreleased)
-	- Added `--verbose` cli option (logLevel 3) to log all requests and display warning when can't inject html file (@pavel)
+	- Added `--verbose` cli option (logLevel 3) (@pavel)
+		- Logs all requests, displays warning when can't inject html file, displays all listening IPv4 interfaces...
 	- HTTPS configuration now also accepts a plain object (@pavel)
 * v1.1.0
 	- Proxy support (@pavel)

--- a/README.md
+++ b/README.md
@@ -51,8 +51,7 @@ Command line parameters:
 * `--verbose | -V` - more logging (logs all requests, etc.)
 * `--open=PATH` - launch browser to PATH instead of server root
 * `--watch=PATH` - comma-separated string of paths to exclusively watch for changes (default: watch everything)
-* `--ignore=PATH` - comma-separated string of paths to ignore
-* `--ignorePattern=RGXP` - Regular expression of files to ignore (ie `.*\.jade`)
+* `--ignore=PATH` - comma-separated string of paths to ignore ([anymatch](https://github.com/es128/anymatch)-compatible definition)
 * `--entry-file=PATH` - serve this file (server root relative) in place of missing files (useful for single page apps)
 * `--mount=ROUTE:PATH` - serve the paths contents under the defined route (multiple definitions possible)
 * `--spa` - translate requests from /abc to /#/abc (handy for Single Page Apps)

--- a/index.js
+++ b/index.js
@@ -127,6 +127,7 @@ function entryPoint(staticHandler, file) {
  * @param root {string} Path to root directory (default: cwd)
  * @param watch {array} Paths to exclusively watch for changes
  * @param ignore {array} Paths to ignore when watching files for changes
+ * @param ignorePattern {regexp} Ignore files by RegExp
  * @param open {string} Subpath to open in browser, use false to suppress launch (default: server root)
  * @param mount {array} Mount directories onto a route, e.g. [['/components', './node_modules']].
  * @param logLevel {number} 0 = errors only, 1 = some, 2 = lots
@@ -316,9 +317,16 @@ LiveServer.start = function(options) {
 		clients.push(ws);
 	});
 
+	var ignored = [];
+	if (options.ignore) {
+		ignored = ignored.concat(options.ignore);
+	}
+	if (options.ignorePattern) {
+		ignored.push(options.ignorePattern);
+	}
 	// Setup file watcher
 	LiveServer.watcher = chokidar.watch(watchPaths, {
-		ignored: options.ignore || false,
+		ignored: ignored,
 		ignoreInitial: true
 	});
 	function handleChange(changePath) {

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ var fs = require('fs'),
 	send = require('send'),
 	open = require('opn'),
 	es = require("event-stream"),
+	os = require('os'),
 	chokidar = require('chokidar');
 require('colors');
 
@@ -244,10 +245,31 @@ LiveServer.start = function(options) {
 		var serveURL = protocol + '://' + serveHost + ':' + address.port;
 		var openURL = protocol + '://' + openHost + ':' + address.port;
 
+		var serveURLs = [ serveURL ];
+		if (address.address === "0.0.0.0") {
+			var ifaces = os.networkInterfaces();
+			serveURLs = Object.keys(ifaces)
+				.map(function (iface) {
+					return ifaces[iface];
+				})
+				// flatten address data, use only IPv4
+				.reduce(function (data, addresses) {
+					addresses.filter(function (address) {
+						return address.family === "IPv4";
+					}).forEach(function (address) {
+						data.push(address);
+					});
+					return data;
+				}, [])
+				.map(function (addr) {
+					return protocol + "://" + addr.address + ":" + address.port;
+				});
+		}
+
 		// Output
 		if (LiveServer.logLevel >= 1) {
 			if (serveURL === openURL)
-				console.log(("Serving \"%s\" at %s").green, root, serveURL);
+				console.log(("Serving \"%s\" at\n\t%s").green, root, serveURLs.join("\n\t"));
 			else
 				console.log(("Serving \"%s\" at %s (%s)").green, root, openURL, serveURL);
 		}

--- a/index.js
+++ b/index.js
@@ -246,7 +246,7 @@ LiveServer.start = function(options) {
 		var openURL = protocol + '://' + openHost + ':' + address.port;
 
 		var serveURLs = [ serveURL ];
-		if (address.address === "0.0.0.0") {
+		if (LiveServer.logLevel > 2 && address.address === "0.0.0.0") {
 			var ifaces = os.networkInterfaces();
 			serveURLs = Object.keys(ifaces)
 				.map(function (iface) {
@@ -269,7 +269,11 @@ LiveServer.start = function(options) {
 		// Output
 		if (LiveServer.logLevel >= 1) {
 			if (serveURL === openURL)
-				console.log(("Serving \"%s\" at\n\t%s").green, root, serveURLs.join("\n\t"));
+				if (serveURLs.length === 1) {
+					console.log(("Serving \"%s\" at %s").green, root, serveURLs[0]);
+				} else {
+					console.log(("Serving \"%s\" at\n\t%s").green, root, serveURLs.join("\n\t"));
+				}
 			else
 				console.log(("Serving \"%s\" at %s (%s)").green, root, openURL, serveURL);
 		}

--- a/index.js
+++ b/index.js
@@ -10,14 +10,14 @@ var fs = require('fs'),
 	send = require('send'),
 	open = require('opn'),
 	es = require("event-stream"),
-	watchr = require('watchr');
+	chokidar = require('chokidar');
 require('colors');
 
 var INJECTED_CODE = fs.readFileSync(path.join(__dirname, "injected.html"), "utf8");
 
 var LiveServer = {
 	server: null,
-	watchers: [],
+	watcher: null,
 	logLevel: 2
 };
 
@@ -126,7 +126,6 @@ function entryPoint(staticHandler, file) {
  * @param root {string} Path to root directory (default: cwd)
  * @param watch {array} Paths to exclusively watch for changes
  * @param ignore {array} Paths to ignore when watching files for changes
- * @param ignorePattern {regexp} Ignore files by RegExp
  * @param open {string} Subpath to open in browser, use false to suppress launch (default: server root)
  * @param mount {array} Mount directories onto a route, e.g. [['/components', './node_modules']].
  * @param logLevel {number} 0 = errors only, 1 = some, 2 = lots
@@ -292,48 +291,41 @@ LiveServer.start = function(options) {
 	});
 
 	// Setup file watcher
-	watchr.watch({
-		paths: watchPaths,
-		ignorePaths: options.ignore || false,
-		ignoreCommonPatterns: true,
-		ignoreHiddenFiles: true,
-		ignoreCustomPatterns: options.ignorePattern || null,
-		preferredMethods: [ 'watchFile', 'watch' ],
-		interval: 1407,
-		listeners: {
-			error: function(err) {
-				console.log("ERROR:".red, err);
-			},
-			change: function(eventName, filePath /*, fileCurrentStat, filePreviousStat*/) {
-				clients.forEach(function(ws) {
-					if (!ws) return;
-					if (path.extname(filePath) === ".css") {
-						ws.send('refreshcss');
-						if (LiveServer.logLevel >= 1)
-							console.log("CSS change detected".magenta, filePath);
-					} else {
-						ws.send('reload');
-						if (LiveServer.logLevel >= 1)
-							console.log("File change detected".cyan, filePath);
-					}
-				});
-			}
-		},
-		next: function(err, watchers) {
-			if (err)
-				console.error("Error watching files:".red, err);
-			LiveServer.watchers = watchers;
-		}
+	LiveServer.watcher = chokidar.watch(watchPaths, {
+		ignored: options.ignore || false,
+		ignoreInitial: true
 	});
+	function handleChange(changePath) {
+		clients.forEach(function (ws) {
+			if (!ws) return;
+			if (path.extname(changePath) === ".css") {
+				ws.send('refreshcss');
+				if (LiveServer.logLevel >= 1)
+					console.log("CSS change detected".magenta, changePath);
+			} else {
+				ws.send('reload');
+				if (LiveServer.logLevel >= 1)
+					console.log("Change detected".cyan, changePath);
+			}
+		});
+	}
+	LiveServer.watcher
+		.on("change", handleChange)
+		.on("add", handleChange)
+		.on("unlink", handleChange)
+		.on("addDir", handleChange)
+		.on("unlinkDir", handleChange)
+		.on("error", function (err) {
+			console.log("ERROR:".red, err);
+		});
 
 	return server;
 };
 
 LiveServer.shutdown = function() {
-	var watchers = LiveServer.watchers;
-	if (watchers) {
-		for (var i = 0; i < watchers.length; ++i)
-			watchers[i].close();
+	var watcher = LiveServer.watcher;
+	if (watcher) {
+		watcher.close();
 	}
 	var server = LiveServer.server;
 	if (server)

--- a/index.js
+++ b/index.js
@@ -249,19 +249,19 @@ LiveServer.start = function(options) {
 		if (LiveServer.logLevel > 2 && address.address === "0.0.0.0") {
 			var ifaces = os.networkInterfaces();
 			serveURLs = Object.keys(ifaces)
-				.map(function (iface) {
+				.map(function(iface) {
 					return ifaces[iface];
 				})
 				// flatten address data, use only IPv4
 				.reduce(function (data, addresses) {
-					addresses.filter(function (address) {
-						return address.family === "IPv4";
-					}).forEach(function (address) {
-						data.push(address);
+					addresses.filter(function(addr) {
+						return addr.family === "IPv4";
+					}).forEach(function(addr) {
+						data.push(addr);
 					});
 					return data;
 				}, [])
-				.map(function (addr) {
+				.map(function(addr) {
 					return protocol + "://" + addr.address + ":" + address.port;
 				});
 		}

--- a/index.js
+++ b/index.js
@@ -315,6 +315,10 @@ LiveServer.start = function(options) {
 		.on("unlink", handleChange)
 		.on("addDir", handleChange)
 		.on("unlinkDir", handleChange)
+		.on("ready", function () {
+			if (LiveServer.logLevel >= 1)
+				console.log("Ready for changes".cyan);
+		})
 		.on("error", function (err) {
 			console.log("ERROR:".red, err);
 		});

--- a/live-server.js
+++ b/live-server.js
@@ -18,7 +18,6 @@ var configPath = path.join(homeDir, '.live-server.json');
 if (fs.existsSync(configPath)) {
 	var userConfig = fs.readFileSync(configPath, 'utf8');
 	assign(opts, JSON.parse(userConfig));
-	if (opts.ignorePattern) opts.ignorePattern = new RegExp(opts.ignorePattern);
 }
 
 for (var i = process.argv.length - 1; i >= 2; --i) {
@@ -50,11 +49,9 @@ for (var i = process.argv.length - 1; i >= 2; --i) {
 	}
 	else if (arg.indexOf("--ignore=") > -1) {
 		// Will be modified later when cwd is known
-		opts.ignore = arg.substring(9).split(",");
-		process.argv.splice(i, 1);
-	}
-	else if (arg.indexOf("--ignorePattern=") > -1) {
-		opts.ignorePattern = new RegExp(arg.substring(16));
+		opts.ignore = arg.substring(9).split(",").filter(function (pattern) {
+			return pattern.trim().length > 0;
+		});
 		process.argv.splice(i, 1);
 	}
 	else if (arg === "--no-browser") {
@@ -124,7 +121,7 @@ for (var i = process.argv.length - 1; i >= 2; --i) {
 		process.argv.splice(i, 1);
 	}
 	else if (arg === "--help" || arg === "-h") {
-		console.log('Usage: live-server [-v|--version] [-h|--help] [-q|--quiet] [--port=PORT] [--host=HOST] [--open=PATH] [--no-browser] [--browser=BROWSER] [--ignore=PATH] [--ignorePattern=RGXP] [--entry-file=PATH] [--spa] [--mount=ROUTE:PATH] [--wait=MILLISECONDS] [--htpasswd=PATH] [--cors] [--https=PATH] [--proxy=PATH] [PATH]');
+		console.log('Usage: live-server [-v|--version] [-h|--help] [-q|--quiet] [--port=PORT] [--host=HOST] [--open=PATH] [--no-browser] [--browser=BROWSER] [--ignore=PATH] [--entry-file=PATH] [--spa] [--mount=ROUTE:PATH] [--wait=MILLISECONDS] [--htpasswd=PATH] [--cors] [--https=PATH] [--proxy=PATH] [PATH]');
 		process.exit();
 	}
 	else if (arg === "--test") {

--- a/live-server.js
+++ b/live-server.js
@@ -18,6 +18,7 @@ var configPath = path.join(homeDir, '.live-server.json');
 if (fs.existsSync(configPath)) {
 	var userConfig = fs.readFileSync(configPath, 'utf8');
 	assign(opts, JSON.parse(userConfig));
+	if (opts.ignorePattern) opts.ignorePattern = new RegExp(opts.ignorePattern);
 }
 
 for (var i = process.argv.length - 1; i >= 2; --i) {
@@ -49,9 +50,11 @@ for (var i = process.argv.length - 1; i >= 2; --i) {
 	}
 	else if (arg.indexOf("--ignore=") > -1) {
 		// Will be modified later when cwd is known
-		opts.ignore = arg.substring(9).split(",").filter(function (pattern) {
-			return pattern.trim().length > 0;
-		});
+		opts.ignore = arg.substring(9).split(",");
+		process.argv.splice(i, 1);
+	}
+	else if (arg.indexOf("--ignorePattern=") > -1) {
+		opts.ignorePattern = new RegExp(arg.substring(16));
 		process.argv.splice(i, 1);
 	}
 	else if (arg === "--no-browser") {
@@ -121,7 +124,7 @@ for (var i = process.argv.length - 1; i >= 2; --i) {
 		process.argv.splice(i, 1);
 	}
 	else if (arg === "--help" || arg === "-h") {
-		console.log('Usage: live-server [-v|--version] [-h|--help] [-q|--quiet] [--port=PORT] [--host=HOST] [--open=PATH] [--no-browser] [--browser=BROWSER] [--ignore=PATH] [--entry-file=PATH] [--spa] [--mount=ROUTE:PATH] [--wait=MILLISECONDS] [--htpasswd=PATH] [--cors] [--https=PATH] [--proxy=PATH] [PATH]');
+		console.log('Usage: live-server [-v|--version] [-h|--help] [-q|--quiet] [--port=PORT] [--host=HOST] [--open=PATH] [--no-browser] [--browser=BROWSER] [--ignore=PATH] [--ignorePattern=RGXP] [--entry-file=PATH] [--spa] [--mount=ROUTE:PATH] [--wait=MILLISECONDS] [--htpasswd=PATH] [--cors] [--https=PATH] [--proxy=PATH] [PATH]');
 		process.exit();
 	}
 	else if (arg === "--test") {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   ],
   "author": "Tapio Vierros",
   "dependencies": {
+    "chokidar": "^1.6.0",
     "colors": "latest",
     "connect": "3.4.x",
     "cors": "latest",
@@ -23,8 +24,7 @@
     "opn": "latest",
     "proxy-middleware": "latest",
     "send": "latest",
-    "serve-index": "^1.7.2",
-    "watchr": "2.6.x"
+    "serve-index": "^1.7.2"
   },
   "devDependencies": {
     "mocha": "^2.3.3",


### PR DESCRIPTION
Closes #137
* [watchr](https://github.com/bevry/watchr) is replaced by [chokidar](https://github.com/paulmillr/chokidar). This change boosts responsiveness of `live-server` to file system changes.
* `--ignorePattern=RGXP` option removed, as `--ignore=PATH` now accepts [anymatch](https://github.com/es128/anymatch) rules, which makes `--ignorePattern=RGXP` option obsolete.