### PR TITLE
Watch speed up

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Command line parameters:
 * `--open=PATH` - launch browser to PATH instead of server root
 * `--watch=PATH` - comma-separated string of paths to exclusively watch for changes (default: watch everything)
 * `--ignore=PATH` - comma-separated string of paths to ignore ([anymatch](https://github.com/es128/anymatch)-compatible definition)
+* `--ignorePattern=RGXP` - Regular expression of files to ignore (ie `.*\.jade`) (**DEPRECATED** in favor of `--ignore`)
 * `--entry-file=PATH` - serve this file (server root relative) in place of missing files (useful for single page apps)
 * `--mount=ROUTE:PATH` - serve the paths contents under the defined route (multiple definitions possible)
 * `--spa` - translate requests from /abc to /#/abc (handy for Single Page Apps)

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Command line parameters:
 * `--entry-file=PATH` - serve this file (server root relative) in place of missing files (useful for single page apps)
 * `--mount=ROUTE:PATH` - serve the paths contents under the defined route (multiple definitions possible)
 * `--spa` - translate requests from /abc to /#/abc (handy for Single Page Apps)
-* `--wait=MILLISECONDS` - wait for all changes, before reloading
+* `--wait=MILLISECONDS` - (default 100ms) wait for all changes, before reloading
 * `--htpasswd=PATH` - Enables http-auth expecting htpasswd file located at PATH
 * `--cors` - Enables CORS for any origin (reflects request origin, requests with credentials are supported)
 * `--https=PATH` - PATH to a HTTPS configuration module

--- a/README.md
+++ b/README.md
@@ -51,8 +51,7 @@ Command line parameters:
 * `--verbose | -V` - more logging (logs all requests, shows all listening IPv4 interfaces, etc.)
 * `--open=PATH` - launch browser to PATH instead of server root
 * `--watch=PATH` - comma-separated string of paths to exclusively watch for changes (default: watch everything)
-* `--ignore=PATH` - comma-separated string of paths to ignore
-* `--ignorePattern=RGXP` - Regular expression of files to ignore (ie `.*\.jade`)
+* `--ignore=PATH` - comma-separated string of paths to ignore ([anymatch](https://github.com/es128/anymatch)-compatible definition)
 * `--entry-file=PATH` - serve this file (server root relative) in place of missing files (useful for single page apps)
 * `--mount=ROUTE:PATH` - serve the paths contents under the defined route (multiple definitions possible)
 * `--spa` - translate requests from /abc to /#/abc (handy for Single Page Apps)

--- a/README.md
+++ b/README.md
@@ -113,8 +113,12 @@ If using the node API, you can also directly pass a configuration object instead
 Troubleshooting
 ---------------
 
-Open your browser's console: there should be a message at the top stating that live reload is enabled. Note that you will need a browser that supports WebSockets. If there are errors, deal with them. If it's still not working, [file an issue](https://github.com/tapio/live-server/issues).
-
+* No reload on changes
+	* Open your browser's console: there should be a message at the top stating that live reload is enabled. Note that you will need a browser that supports WebSockets. If there are errors, deal with them. If it's still not working, [file an issue](https://github.com/tapio/live-server/issues).
+* Error: watch <PATH> ENOSPC
+	* See [this suggested solution](http://stackoverflow.com/questions/22475849/node-js-error-enospc/32600959#32600959).
+* Reload works but changes are missing or outdated
+	* Try using `--wait=MS` option. Where `MS` is time in milliseconds to wait before issuing a reload.
 
 How it works
 ------------

--- a/index.js
+++ b/index.js
@@ -127,6 +127,7 @@ function entryPoint(staticHandler, file) {
  * @param root {string} Path to root directory (default: cwd)
  * @param watch {array} Paths to exclusively watch for changes
  * @param ignore {array} Paths to ignore when watching files for changes
+ * @param ignorePattern {regexp} Ignore files by RegExp
  * @param open {string} Subpath to open in browser, use false to suppress launch (default: server root)
  * @param mount {array} Mount directories onto a route, e.g. [['/components', './node_modules']].
  * @param logLevel {number} 0 = errors only, 1 = some, 2 = lots
@@ -316,9 +317,16 @@ LiveServer.start = function(options) {
 		clients.push(ws);
 	});
 
+	var ignored = [];
+	if (options.ignore) {
+		ignored = ignored.concat(options.ignore);
+	}
+	if (options.ignorePattern) {
+		ignored.push(options.ignorePattern);
+	}
 	// Setup file watcher
 	LiveServer.watcher = chokidar.watch(watchPaths, {
-		ignored: options.ignore || false,
+		ignored: ignored,
 		ignoreInitial: true
 	});
 	function handleChange(changePath) {

--- a/index.js
+++ b/index.js
@@ -341,6 +341,10 @@ LiveServer.start = function(options) {
 		.on("unlink", handleChange)
 		.on("addDir", handleChange)
 		.on("unlinkDir", handleChange)
+		.on("ready", function () {
+			if (LiveServer.logLevel >= 1)
+				console.log("Ready for changes".cyan);
+		})
 		.on("error", function (err) {
 			console.log("ERROR:".red, err);
 		});

--- a/index.js
+++ b/index.js
@@ -150,7 +150,10 @@ LiveServer.start = function(options) {
 	if (options.noBrowser) openPath = null; // Backwards compatibility with 0.7.0
 	var file = options.file;
 	var staticServerHandler = staticServer(root, spa);
-	var wait = options.wait || 0;
+	var wait = options.wait;
+	if (wait == null) {
+		wait = 100;
+	}
 	var browser = options.browser || null;
 	var htpasswd = options.htpasswd || null;
 	var cors = options.cors || false;

--- a/live-server.js
+++ b/live-server.js
@@ -18,7 +18,6 @@ var configPath = path.join(homeDir, '.live-server.json');
 if (fs.existsSync(configPath)) {
 	var userConfig = fs.readFileSync(configPath, 'utf8');
 	assign(opts, JSON.parse(userConfig));
-	if (opts.ignorePattern) opts.ignorePattern = new RegExp(opts.ignorePattern);
 }
 
 for (var i = process.argv.length - 1; i >= 2; --i) {
@@ -50,11 +49,9 @@ for (var i = process.argv.length - 1; i >= 2; --i) {
 	}
 	else if (arg.indexOf("--ignore=") > -1) {
 		// Will be modified later when cwd is known
-		opts.ignore = arg.substring(9).split(",");
-		process.argv.splice(i, 1);
-	}
-	else if (arg.indexOf("--ignorePattern=") > -1) {
-		opts.ignorePattern = new RegExp(arg.substring(16));
+		opts.ignore = arg.substring(9).split(",").filter(function (pattern) {
+			return pattern.trim().length > 0;
+		});
 		process.argv.splice(i, 1);
 	}
 	else if (arg === "--no-browser") {
@@ -124,7 +121,7 @@ for (var i = process.argv.length - 1; i >= 2; --i) {
 		process.argv.splice(i, 1);
 	}
 	else if (arg === "--help" || arg === "-h") {
-		console.log('Usage: live-server [-v|--version] [-h|--help] [-q|--quiet] [--port=PORT] [--host=HOST] [--open=PATH] [--no-browser] [--browser=BROWSER] [--ignore=PATH] [--ignorePattern=RGXP] [--entry-file=PATH] [--spa] [--mount=ROUTE:PATH] [--wait=MILLISECONDS] [--htpasswd=PATH] [--cors] [--https=PATH] [--proxy=PATH] [PATH]');
+		console.log('Usage: live-server [-v|--version] [-h|--help] [-q|--quiet] [--port=PORT] [--host=HOST] [--open=PATH] [--no-browser] [--browser=BROWSER] [--ignore=PATH] [--entry-file=PATH] [--spa] [--mount=ROUTE:PATH] [--wait=MILLISECONDS] [--htpasswd=PATH] [--cors] [--https=PATH] [--proxy=PATH] [PATH]');
 		process.exit();
 	}
 	else if (arg === "--test") {

--- a/live-server.js
+++ b/live-server.js
@@ -18,6 +18,7 @@ var configPath = path.join(homeDir, '.live-server.json');
 if (fs.existsSync(configPath)) {
 	var userConfig = fs.readFileSync(configPath, 'utf8');
 	assign(opts, JSON.parse(userConfig));
+	if (opts.ignorePattern) opts.ignorePattern = new RegExp(opts.ignorePattern);
 }
 
 for (var i = process.argv.length - 1; i >= 2; --i) {
@@ -49,9 +50,11 @@ for (var i = process.argv.length - 1; i >= 2; --i) {
 	}
 	else if (arg.indexOf("--ignore=") > -1) {
 		// Will be modified later when cwd is known
-		opts.ignore = arg.substring(9).split(",").filter(function (pattern) {
-			return pattern.trim().length > 0;
-		});
+		opts.ignore = arg.substring(9).split(",");
+		process.argv.splice(i, 1);
+	}
+	else if (arg.indexOf("--ignorePattern=") > -1) {
+		opts.ignorePattern = new RegExp(arg.substring(16));
 		process.argv.splice(i, 1);
 	}
 	else if (arg === "--no-browser") {
@@ -121,7 +124,7 @@ for (var i = process.argv.length - 1; i >= 2; --i) {
 		process.argv.splice(i, 1);
 	}
 	else if (arg === "--help" || arg === "-h") {
-		console.log('Usage: live-server [-v|--version] [-h|--help] [-q|--quiet] [--port=PORT] [--host=HOST] [--open=PATH] [--no-browser] [--browser=BROWSER] [--ignore=PATH] [--entry-file=PATH] [--spa] [--mount=ROUTE:PATH] [--wait=MILLISECONDS] [--htpasswd=PATH] [--cors] [--https=PATH] [--proxy=PATH] [PATH]');
+		console.log('Usage: live-server [-v|--version] [-h|--help] [-q|--quiet] [--port=PORT] [--host=HOST] [--open=PATH] [--no-browser] [--browser=BROWSER] [--ignore=PATH] [--ignorePattern=RGXP] [--entry-file=PATH] [--spa] [--mount=ROUTE:PATH] [--wait=MILLISECONDS] [--htpasswd=PATH] [--cors] [--https=PATH] [--proxy=PATH] [PATH]');
 		process.exit();
 	}
 	else if (arg === "--test") {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   ],
   "author": "Tapio Vierros",
   "dependencies": {
+    "chokidar": "^1.6.0",
     "colors": "latest",
     "connect": "3.4.x",
     "cors": "latest",
@@ -23,8 +24,7 @@
     "opn": "latest",
     "proxy-middleware": "latest",
     "send": "latest",
-    "serve-index": "^1.7.2",
-    "watchr": "2.6.x"
+    "serve-index": "^1.7.2"
   },
   "devDependencies": {
     "mocha": "^2.3.3",


### PR DESCRIPTION
Closes #137
* [watchr](https://github.com/bevry/watchr) is replaced by [chokidar](https://github.com/paulmillr/chokidar). This change boosts responsiveness of `live-server` to file system changes.
* `--ignorePattern=RGXP` option is now deprecated, as `--ignore=PATH` now accepts [anymatch](https://github.com/es128/anymatch) rules.
* `--wait` option now has a default value of 100ms, to reduce issues with various OS file system watchers.