### PR TITLE
Add --proxy-unsecure option

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Command line parameters:
 * `--cors` - Enables CORS for any origin (reflects request origin, requests with credentials are supported)
 * `--https=PATH` - PATH to a HTTPS configuration module
 * `--proxy=ROUTE:URL` - proxy all requests for ROUTE to URL
+* `--proxy-unsecure` - don't check hostname for https proxy requests (prevents *Hostname / IP doesn't match certificate's altname* error)
 * `--help | -h` - display terse usage hint and exit
 * `--version | -v` - display version and exit
 
@@ -147,6 +148,7 @@ Version history
 	- HTTPS configuration now also accepts a plain object (@pavel)
 	- Move `--spa` to a bundled middleware file
 	- New bundled `spa-no-assets` middleware that works like `spa` but ignores requests with extension
+    - Add `--proxy-unsecure` parameter to allow overriding hostname check for https proxy requests (@miqmago)
 * v1.1.0
 	- Proxy support (@pavel)
 	- Middleware support (@achandrasekar)

--- a/index.js
+++ b/index.js
@@ -204,6 +204,11 @@ LiveServer.start = function(options) {
 		var proxyOpts = url.parse(proxyRule[1]);
 		proxyOpts.via = true;
 		proxyOpts.preserveHost = true;
+        if (options.unsecureProxy) {
+            proxyOpts.checkServerIdentity = function () {
+                return undefined;
+            };
+        }
 		app.use(proxyRule[0], require('proxy-middleware')(proxyOpts));
 		if (LiveServer.logLevel >= 1)
 			console.log('Mapping %s to "%s"', proxyRule[0], proxyRule[1]);

--- a/live-server.js
+++ b/live-server.js
@@ -124,12 +124,16 @@ for (var i = process.argv.length - 1; i >= 2; --i) {
 		opts.proxy.push([ match[1], match[2] ]);
 		process.argv.splice(i, 1);
 	}
+	else if (arg.indexOf("--proxy-unsecure") > -1) {
+		opts.unsecureProxy = true;
+		process.argv.splice(i, 1);
+	}
 	else if (arg.indexOf("--middleware=") > -1) {
 		opts.middleware.push(arg.substring(13));
 		process.argv.splice(i, 1);
 	}
 	else if (arg === "--help" || arg === "-h") {
-		console.log('Usage: live-server [-v|--version] [-h|--help] [-q|--quiet] [--port=PORT] [--host=HOST] [--open=PATH] [--no-browser] [--browser=BROWSER] [--ignore=PATH] [--ignorePattern=RGXP] [--entry-file=PATH] [--spa] [--mount=ROUTE:PATH] [--wait=MILLISECONDS] [--htpasswd=PATH] [--cors] [--https=PATH] [--proxy=PATH] [PATH]');
+		console.log('Usage: live-server [-v|--version] [-h|--help] [-q|--quiet] [--port=PORT] [--host=HOST] [--open=PATH] [--no-browser] [--browser=BROWSER] [--ignore=PATH] [--ignorePattern=RGXP] [--entry-file=PATH] [--spa] [--mount=ROUTE:PATH] [--wait=MILLISECONDS] [--htpasswd=PATH] [--cors] [--https=PATH] [--proxy=PATH] [--proxy-unsecure] [PATH]');
 		process.exit();
 	}
 	else if (arg === "--test") {


### PR DESCRIPTION
When requesting proxied https, it returns the following error: `Hostname / IP doesn't match certificate's altname`. With this option, hostname check is disallowed. Don't know how to implement a test for it...

See this thread: http://stackoverflow.com/a/27551126