### PR TITLE
support for multiple --open arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,7 +120,7 @@ function entryPoint(staticHandler, file) {
  * @param watch {array} Paths to exclusively watch for changes
  * @param ignore {array} Paths to ignore when watching files for changes
  * @param ignorePattern {regexp} Ignore files by RegExp
- * @param open {string} Subpath to open in browser, use false to suppress launch (default: server root)
+ * @param open {(string|string[])} Subpath(s) to open in browser, use false to suppress launch (default: server root)
  * @param mount {array} Mount directories onto a route, e.g. [['/components', './node_modules']].
  * @param logLevel {number} 0 = errors only, 1 = some, 2 = lots
  * @param file {string} Path to the entry point file
@@ -285,7 +285,13 @@ LiveServer.start = function(options) {
 
 		// Launch browser
 		if (openPath !== null)
-			open(openURL + openPath, {app: browser});
+			if (typeof openPath === "object") {
+				openPath.forEach(function(p) {
+					open(openURL + p, {app: browser});
+				});
+			} else {
+				open(openURL + openPath, {app: browser});
+			}
 	});
 
 	// Setup server to listen at port

--- a/live-server.js
+++ b/live-server.js
@@ -41,7 +41,17 @@ for (var i = process.argv.length - 1; i >= 2; --i) {
 		if (open.indexOf('/') !== 0) {
 			open = '/' + open;
 		}
-		opts.open = open;
+		switch (typeof opts.open) {
+			case "boolean":
+				opts.open = open;
+				break;
+			case "string":
+				opts.open = [opts.open, open];
+				break;
+			case "object":
+				opts.open.push(open);
+				break;
+		}
 		process.argv.splice(i, 1);
 	}
 	else if (arg.indexOf("--watch=") > -1) {


### PR DESCRIPTION
This adds the functionality for opening multiple paths in the same window on initial serve.

For example, suppose you have a todo list page at `/todo/` in your current project that you want to open with the web root. You can do this by using multiple `--open` arguments:

```sh
$ live-server --open=/ --open=/todo/
```

Both pages will open in the browser.