### PR TITLE
support mounting directly under the root directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -201,6 +201,13 @@ LiveServer.start = function(options) {
 			console.log('Mapping %s to "%s"', mountRule[0], mountPath);
 	});
 	proxy.forEach(function(proxyRule) {
+		if (mountRule.length === 1) {
+			var mountPath = path.resolve(process.cwd(), mountRule[0]);
+			app.use(staticServer(mountPath));
+			if (LiveServer.logLevel >= 1)
+				console.log('Mapping to "%s"', mountPath);
+			return;
+		}
 		var proxyOpts = url.parse(proxyRule[1]);
 		proxyOpts.via = true;
 		proxyOpts.preserveHost = true;


### PR DESCRIPTION
For the following mounting rules, files under the bower_components directory will be served with any prefix.

```
   {
   ...
    mount: [['./bower_components']], // Mount a directory to a route.
   ...
   }
```

For example:

  ` http://localhost:8181/live-server/index.js  `

will be serving file from ./bower_components/live-server/index.js which previously is not possible.