### PR TITLE
fix issue #165: no body tag case. inject in head.

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ function staticServer(root) {
 		if (req.method !== "GET" && req.method !== "HEAD") return next();
 		var reqpath = isFile ? "" : url.parse(req.url).pathname;
 		var hasNoOrigin = !req.headers.origin;
-		var injectCandidates = [ new RegExp("</body>", "i"), new RegExp("</svg>") ];
+		var injectCandidates = [ new RegExp("</body>", "i"), new RegExp("</svg>"), new RegExp("</head>", "i")];
 		var injectTag = null;
 
 		function directory() {


### PR DESCRIPTION
I encountered similar situation to issue #165. minimum html page may not have a body so added check for head closing tag for javascript injection in manner similar to body closing tag check.