### PR TITLE
log when live reload failure instead of success

### DIFF
--- a/injected.html
+++ b/injected.html
@@ -24,8 +24,7 @@
 				if (msg.data == 'reload') window.location.reload();
 				else if (msg.data == 'refreshcss') refreshCSS();
 			};
-			console.log('Live reload enabled.');
 		})();
-	}
+	} else console.log('No WebSocket found: Live reload not enabled.');
 	// ]]>
 </script>


### PR DESCRIPTION
When doing any type of JavaScript development, it's quite a nuisance having the log
include 'Live reload enabled.' after every refresh. Instead, log to the console when
something unexpected has happened.