### PR TITLE
Support relative path specified for `middleware`

### DIFF
--- a/index.js
+++ b/index.js
@@ -170,8 +170,11 @@ LiveServer.start = function(options) {
 			var ext = path.extname(mw).toLocaleLowerCase();
 			if (ext !== ".js") {
 				mw = require(path.join(__dirname, "middleware", mw + ".js"));
-			} else {
+			}
+			else if (path.isAbsolute(mw)) {
 				mw = require(mw);
+			} else {
+				mw = require(path.join(root, mw));
 			}
 		}
 		app.use(mw);


### PR DESCRIPTION
I want to add my own middleware to my project like this:

```
├── index.html
├── app.js
├── package.json
├── disable-cache.js      // middleware
```

And specify it by executing live-server from the command line like this:

```
live-server --middleware=./disable-cache.js
```

It didn't appear that live-server supports custom middleware specified with a relative path -- only an absolute one. This PR adds support for relative paths. If this is a desirable feature, I can add tests.

However, there is a **caveat** I am aware of: When `root` is not specified, it defaults to `process.cwd()`:

```
LiveServer.start = function(options) {
  var root = options.root || process.cwd();
  // ...
```

This is an absolute path, so our `require` call for the middleware will work. However, if the user specifies `root` like this:

```
live-server . --middleware=./disable-cache.js
```

`root` is now a _relative_ path. So the `require` will fail.

Broadly, I don't imagine having `root` be relative is desirable. Should we convert a user-specified relative path for `root` to an absolute path? 