### PR TITLE
Https default

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Command line parameters:
 * `--wait=MILLISECONDS` - (default 100ms) wait for all changes, before reloading
 * `--htpasswd=PATH` - Enables http-auth expecting htpasswd file located at PATH
 * `--cors` - Enables CORS for any origin (reflects request origin, requests with credentials are supported)
-* `--https=PATH` - PATH to a HTTPS configuration module
+* `--https=PATH` - PATH to a HTTPS configuration module; if no PATH, a generic (expired) certification is used
 * `--proxy=ROUTE:URL` - proxy all requests for ROUTE to URL
 * `--help | -h` - display terse usage hint and exit
 * `--version | -v` - display version and exit
@@ -95,6 +95,7 @@ HTTPS
 ---------------
 
 In order to enable HTTPS support, you'll need to create a configuration module.
+If no module is provided, a generic, self-signed certification is used. This is **unsuitable for production** but works well for testing with zero-setup.
 The module must export an object that will be used to configure a HTTPS server.
 The keys are the same as the keys in `options` for [tls.createServer](https://nodejs.org/api/tls.html#tls_tls_createserver_options_secureconnectionlistener).
 

--- a/live-server.js
+++ b/live-server.js
@@ -128,6 +128,10 @@ for (var i = process.argv.length - 1; i >= 2; --i) {
 		opts.https = arg.substring(8);
 		process.argv.splice(i, 1);
 	}
+	else if (arg.indexOf("--https") > -1) {
+		opts.https = path.join(__dirname, 'test/conf/https.conf.js');
+		process.argv.splice(i, 1);
+	}
 	else if (arg.indexOf("--proxy=") > -1) {
 		// split only on the first ":", as the URL will contain ":" as well
 		var match = arg.substring(8).match(/([^:]+):(.+)$/);

--- a/live-server.js
+++ b/live-server.js
@@ -143,7 +143,7 @@ for (var i = process.argv.length - 1; i >= 2; --i) {
 		process.argv.splice(i, 1);
 	}
 	else if (arg === "--help" || arg === "-h") {
-		console.log('Usage: live-server [-v|--version] [-h|--help] [-q|--quiet] [--port=PORT] [--host=HOST] [--open=PATH] [--no-browser] [--browser=BROWSER] [--ignore=PATH] [--ignorePattern=RGXP] [--entry-file=PATH] [--spa] [--mount=ROUTE:PATH] [--wait=MILLISECONDS] [--htpasswd=PATH] [--cors] [--https=PATH] [--proxy=PATH] [PATH]');
+		console.log('Usage: live-server [-v|--version] [-h|--help] [-q|--quiet] [--port=PORT] [--host=HOST] [--open=PATH] [--no-browser] [--browser=BROWSER] [--ignore=PATH] [--ignorePattern=RGXP] [--entry-file=PATH] [--spa] [--mount=ROUTE:PATH] [--wait=MILLISECONDS] [--htpasswd=PATH] [--cors] [--https[=PATH]] [--proxy=PATH] [PATH]');
 		process.exit();
 	}
 	else if (arg === "--test") {

--- a/test/cli.js
+++ b/test/cli.js
@@ -62,4 +62,12 @@ describe('command line usage', function() {
 			done();
 		});
 	});
+	it("--https", function(done) {
+		exec_test(["--https", "--no-browser", "--test"], function(error, stdout, stdin) {
+			assert(!error, error);
+			assert(stdout.indexOf("Serving") == 0, "serving string not found");
+			assert(stdout.indexOf("at https://127.0.0.1:") != -1, "https host string not found");
+			done();
+		});
+	});
 });


### PR DESCRIPTION
As mentioned in #170, this allows for a dead-simple implementation of using `live-server` over https by using the credentials in the `test` folder. Although not suitable for a production product, it works perfectly well for using https with zero setup.

The CLI change is that `live-server --https` (with no value) uses the credentials in the `test/` folder.