### PR TITLE
Add noCssInject option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Command line parameters:
 * `--watch=PATH` - comma-separated string of paths to exclusively watch for changes (default: watch everything)
 * `--ignore=PATH` - comma-separated string of paths to ignore ([anymatch](https://github.com/es128/anymatch)-compatible definition)
 * `--ignorePattern=RGXP` - Regular expression of files to ignore (ie `.*\.jade`) (**DEPRECATED** in favor of `--ignore`)
+* `--no-css-inject` - reload page on CSS change, rather than injecting changed CSS
 * `--middleware=PATH` - path to .js file exporting a middleware function to add; can be a name without path nor extension to reference bundled middlewares in `middleware` folder
 * `--entry-file=PATH` - serve this file (server root relative) in place of missing files (useful for single page apps)
 * `--mount=ROUTE:PATH` - serve the paths contents under the defined route (multiple definitions possible)

--- a/index.js
+++ b/index.js
@@ -120,6 +120,7 @@ function entryPoint(staticHandler, file) {
  * @param watch {array} Paths to exclusively watch for changes
  * @param ignore {array} Paths to ignore when watching files for changes
  * @param ignorePattern {regexp} Ignore files by RegExp
+ * @param noCssInject Don't inject CSS changes, just reload as with any other file change
  * @param open {(string|string[])} Subpath(s) to open in browser, use false to suppress launch (default: server root)
  * @param mount {array} Mount directories onto a route, e.g. [['/components', './node_modules']].
  * @param logLevel {number} 0 = errors only, 1 = some, 2 = lots
@@ -148,6 +149,7 @@ LiveServer.start = function(options) {
 	var https = options.https || null;
 	var proxy = options.proxy || [];
 	var middleware = options.middleware || [];
+	var noCssInject = options.noCssInject
 
 	// Setup a web server
 	var app = connect();
@@ -343,7 +345,7 @@ LiveServer.start = function(options) {
 		ignoreInitial: true
 	});
 	function handleChange(changePath) {
-		var cssChange = path.extname(changePath) === ".css";
+		var cssChange = path.extname(changePath) === ".css" && !noCssInject;
 		if (LiveServer.logLevel >= 1) {
 			if (cssChange)
 				console.log("CSS change detected".magenta, changePath);

--- a/live-server.js
+++ b/live-server.js
@@ -68,6 +68,10 @@ for (var i = process.argv.length - 1; i >= 2; --i) {
 		opts.ignorePattern = new RegExp(arg.substring(16));
 		process.argv.splice(i, 1);
 	}
+	else if (arg === "--no-css-inject") {
+		opts.noCssInject = true;
+		process.argv.splice(i, 1);
+	}
 	else if (arg === "--no-browser") {
 		opts.open = false;
 		process.argv.splice(i, 1);
@@ -139,7 +143,7 @@ for (var i = process.argv.length - 1; i >= 2; --i) {
 		process.argv.splice(i, 1);
 	}
 	else if (arg === "--help" || arg === "-h") {
-		console.log('Usage: live-server [-v|--version] [-h|--help] [-q|--quiet] [--port=PORT] [--host=HOST] [--open=PATH] [--no-browser] [--browser=BROWSER] [--ignore=PATH] [--ignorePattern=RGXP] [--entry-file=PATH] [--spa] [--mount=ROUTE:PATH] [--wait=MILLISECONDS] [--htpasswd=PATH] [--cors] [--https=PATH] [--proxy=PATH] [PATH]');
+		console.log('Usage: live-server [-v|--version] [-h|--help] [-q|--quiet] [--port=PORT] [--host=HOST] [--open=PATH] [--no-browser] [--browser=BROWSER] [--ignore=PATH] [--ignorePattern=RGXP] [--no-css-inject] [--entry-file=PATH] [--spa] [--mount=ROUTE:PATH] [--wait=MILLISECONDS] [--htpasswd=PATH] [--cors] [--https=PATH] [--proxy=PATH] [PATH]');
 		process.exit();
 	}
 	else if (arg === "--test") {


### PR DESCRIPTION
With this option set, CSS files cause a page reload as with any other file type. This is especially useful when using live-server with a tool stack such that you have CSS files processed dynamically by JavaScript on the page.