### PR TITLE
Adding `--config` parameter to support specifying configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 Version history
 ---------------
 
+* v1.2.1
+	- Add `--config` parameter to support specifying configuration files
 * v1.2.0
 	- Add `--middleware` parameter to use external middlewares
 	- `middleware` API parameter now also accepts strings similar to `--middleware`

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Command line parameters:
 * `--cors` - Enables CORS for any origin (reflects request origin, requests with credentials are supported)
 * `--https=PATH` - PATH to a HTTPS configuration module
 * `--proxy=ROUTE:URL` - proxy all requests for ROUTE to URL
+* `--config=FILE` - specify a JSON configuration file to be used. Inline arguments take precedence.
 * `--help | -h` - display terse usage hint and exit
 * `--version | -v` - display version and exit
 

--- a/live-server.js
+++ b/live-server.js
@@ -147,7 +147,7 @@ for (var i = process.argv.length - 1; i >= 2; --i) {
 		process.argv.splice(i, 1);
 	}
 	else if (arg === "--help" || arg === "-h") {
-		console.log('Usage: live-server [-v|--version] [-h|--help] [-q|--quiet] [--port=PORT] [--host=HOST] [--open=PATH] [--no-browser] [--browser=BROWSER] [--ignore=PATH] [--ignorePattern=RGXP] [--entry-file=PATH] [--spa] [--mount=ROUTE:PATH] [--wait=MILLISECONDS] [--htpasswd=PATH] [--cors] [--https=PATH] [--proxy=PATH] [PATH]');
+		console.log('Usage: live-server [-v|--version] [-h|--help] [-q|--quiet] [--port=PORT] [--host=HOST] [--open=PATH] [--no-browser] [--browser=BROWSER] [--ignore=PATH] [--ignorePattern=RGXP] [--entry-file=PATH] [--spa] [--mount=ROUTE:PATH] [--wait=MILLISECONDS] [--htpasswd=PATH] [--cors] [--https=PATH] [--proxy=PATH] [--config=FILE] [PATH]');
 		process.exit();
 	}
 	else if (arg === "--test") {

--- a/live-server.js
+++ b/live-server.js
@@ -15,11 +15,16 @@ var opts = {
 };
 
 var homeDir = process.env[(process.platform === 'win32') ? 'USERPROFILE' : 'HOME'];
-var homeConfigPath = path.join(homeDir, '.live-server.json');
-var localConfigPath = path.join('./', '.live-server.json');
-var configPath = fs.existsSync(localConfigPath) ? localConfigPath : fs.existsSync(homeConfigPath) ? homeConfigPath : null; 
-
-if (configPath) {
+var configPath = path.join(homeDir, '.live-server.json');
+for (var i = process.argv.length - 1; i >= 2; --i) {
+	var arg = process.argv[i];
+	if (arg.indexOf("--config=") > -1) {
+		configPath = arg.substring(9);
+		process.argv.splice(i, 1);
+		break;
+	}
+}
+if (fs.existsSync(configPath)) {
 	var userConfig = fs.readFileSync(configPath, 'utf8');
 	assign(opts, JSON.parse(userConfig));
 	if (opts.ignorePattern) opts.ignorePattern = new RegExp(opts.ignorePattern);

--- a/live-server.js
+++ b/live-server.js
@@ -15,8 +15,11 @@ var opts = {
 };
 
 var homeDir = process.env[(process.platform === 'win32') ? 'USERPROFILE' : 'HOME'];
-var configPath = path.join(homeDir, '.live-server.json');
-if (fs.existsSync(configPath)) {
+var homeConfigPath = path.join(homeDir, '.live-server.json');
+var localConfigPath = path.join('./', '.live-server.json');
+var configPath = fs.existsSync(localConfigPath) ? localConfigPath : fs.existsSync(homeConfigPath) ? homeConfigPath : null; 
+
+if (configPath) {
 	var userConfig = fs.readFileSync(configPath, 'utf8');
 	assign(opts, JSON.parse(userConfig));
 	if (opts.ignorePattern) opts.ignorePattern = new RegExp(opts.ignorePattern);

--- a/test/cli.js
+++ b/test/cli.js
@@ -70,12 +70,17 @@ describe('command line usage', function() {
 			done();
 		});
 	});
-	it('--port should take precence over --config', function(done) {
-		exec_test([ "--config=test/data/.live-server.json", "--port=54321", "--no-browser", "--test" ], function(error, stdout, stdin) {
+	it('inline options should take precence over --config', function(done) {
+		exec_test([ 
+			"--port=54321",
+			"--config=test/data/.live-server.json",
+			"--host=127.0.0.1", 
+			"--no-browser", 
+			"--test" ], function(error, stdout, stdin) {
 			assert(!error, error);
 			assert(stdout.indexOf("Serving") == 0, "serving string not found");
-			assert(stdout.indexOf("at http://localhost:54321") != -1, "Failed to read config frm the configuration file!");
+			assert(stdout.indexOf("at http://127.0.0.1:54321") != -1, "Failed to read config frm the configuration file!");
 			done();
 		});
-	})
+	});
 });

--- a/test/cli.js
+++ b/test/cli.js
@@ -62,4 +62,20 @@ describe('command line usage', function() {
 			done();
 		});
 	});
+	it('--config', function(done) {
+		exec_test([ "--config=test/data/.live-server.json", "--no-browser", "--test" ], function(error, stdout, stdin) {
+			assert(!error, error);
+			assert(stdout.indexOf("Serving") == 0, "serving string not found");
+			assert(stdout.indexOf("at http://localhost:12345") != -1, "Failed to read config frm the configuration file!");
+			done();
+		});
+	});
+	it('--port should take precence over --config', function(done) {
+		exec_test([ "--config=test/data/.live-server.json", "--port=54321", "--no-browser", "--test" ], function(error, stdout, stdin) {
+			assert(!error, error);
+			assert(stdout.indexOf("Serving") == 0, "serving string not found");
+			assert(stdout.indexOf("at http://localhost:54321") != -1, "Failed to read config frm the configuration file!");
+			done();
+		});
+	})
 });

--- a/test/data/.live-server.json
+++ b/test/data/.live-server.json
@@ -1,4 +1,4 @@
 {
-  "host" : "localhost",
+  "host": "localhost",
   "port": 12345
 }

--- a/test/data/.live-server.json
+++ b/test/data/.live-server.json
@@ -1,0 +1,4 @@
+{
+  "host" : "localhost",
+  "port": 12345
+}


### PR DESCRIPTION
Small change to support specifying JSON config files via --config argument. This is useful if your project has more than one setup that needs to be used in different situations. For example, one config file containing proxy configuration pointing to real test servers and another one pointing to your local box. Easy switching with this option.