### PR TITLE
Fix 138 - loading project config

### DIFF
--- a/live-server.js
+++ b/live-server.js
@@ -148,7 +148,9 @@ for (var i = process.argv.length - 1; i >= 2; --i) {
 }
 
 // Patch paths
-var dir = opts.root = process.argv[2] || "";
+opts.root = opts.root || process.argv[2] || process.cwd();
+if (opts.root) opts.root = path.resolve(opts.root);
+var dir = opts.root;
 
 if (opts.watch) {
 	opts.watch = opts.watch.map(function(relativePath) {

--- a/live-server.js
+++ b/live-server.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 var path = require('path');
-var fs = require('fs');
 var assign = require('object-assign');
 var liveServer = require("./index");
 
@@ -15,12 +14,11 @@ var opts = {
 };
 
 var homeDir = process.env[(process.platform === 'win32') ? 'USERPROFILE' : 'HOME'];
-var configPath = path.join(homeDir, '.live-server.json');
-if (fs.existsSync(configPath)) {
-	var userConfig = fs.readFileSync(configPath, 'utf8');
-	assign(opts, JSON.parse(userConfig));
-	if (opts.ignorePattern) opts.ignorePattern = new RegExp(opts.ignorePattern);
-}
+assign(opts, readSettings(path.join(homeDir, '.live-server')));
+assign(opts, readSettings(path.join(process.cwd(), '.live-server')));
+
+// Make sure we convert string patterns to regex.
+if (typeof opts.ignorePattern === 'string') opts.ignorePattern = new RegExp(opts.ignorePattern);
 
 for (var i = process.argv.length - 1; i >= 2; --i) {
 	var arg = process.argv[i];
@@ -161,6 +159,15 @@ if (opts.ignore) {
 	opts.ignore = opts.ignore.map(function(relativePath) {
 		return path.join(dir, relativePath);
 	});
+}
+
+function readSettings(filepath) {
+	try {
+		return require(filepath);
+	}
+	catch(ex) {
+		return {};
+	}
 }
 
 liveServer.start(opts);


### PR DESCRIPTION
Changes for supporting loading of project configurations. I have changed the way config files are actually loaded. Instead of using fs, I am using `require`. This has several benefits:

1. It can load a JSON file
2. It can load a JS module
3. It can load a `.live-server` directory with a corresponding `index.js`, which allows you to isolate custom setups with local files. This helps prevent leaking custom live-server files to the rest of your project setup.

Also - tweaked the `root` setup logic so that you can define it in the config file.

-- All tests pass.