### PR TITLE
add EOF injection support when <body> or <head> is missing.

### DIFF
--- a/live-server.js
+++ b/live-server.js
@@ -147,7 +147,7 @@ for (var i = process.argv.length - 1; i >= 2; --i) {
 		process.argv.splice(i, 1);
 	}
 	else if (arg === "--help" || arg === "-h") {
-		console.log('Usage: live-server [-v|--version] [-h|--help] [-q|--quiet] [--port=PORT] [--host=HOST] [--open=PATH] [--no-browser] [--browser=BROWSER] [--ignore=PATH] [--ignorePattern=RGXP] [--no-css-inject] [--entry-file=PATH] [--spa] [--mount=ROUTE:PATH] [--wait=MILLISECONDS] [--htpasswd=PATH] [--cors] [--https=PATH] [--https-module=MODULE_NAME] [--proxy=PATH] [PATH]');
+		console.log('Usage: live-server [-v|--version] [-h|--help] [-q|--quiet] [--port=PORT] [--host=HOST] [--open=PATH] [--no-browser] [--browser=BROWSER] [--ignore=PATH] [--ignorePattern=RGXP] [--no-css-inject] [--inject-eof] [--entry-file=PATH] [--spa] [--mount=ROUTE:PATH] [--wait=MILLISECONDS] [--htpasswd=PATH] [--cors] [--https=PATH] [--https-module=MODULE_NAME] [--proxy=PATH] [PATH]');
 		process.exit();
 	}
 	else if (arg === "--test") {
@@ -155,6 +155,13 @@ for (var i = process.argv.length - 1; i >= 2; --i) {
 		setTimeout(liveServer.shutdown, 500);
 		process.argv.splice(i, 1);
 	}
+  else if (arg === "--inject-eof") {
+    // If no </body> or </head> is, inject at EOF
+    opts.injectEOF = true
+    process.argv.splice(i, 1);
+  }
+
+
 }
 
 // Patch paths

--- a/test/data/index-eof.html
+++ b/test/data/index-eof.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>Live-server Test Page</title>
+<link rel="stylesheet" href="style.css" />


### PR DESCRIPTION
Hi there,

I am the creator [lagom.js](https://reimertz.github.io/lagom), a presentation generator. 

This is an how an a presentation could look like, see how `<html>`,`<head>` and `<body>` is missing. 

```
<!DOCTYPE html>
<meta charset="UTF-8">
<title>asocial</title>
<link rel=stylesheet href="styles/lagom.css">

<section>
  <h1>A slide</h1>
</section>

<script src="scripts/lagom.js"></script>
```

It is not very well known but this is okay according to the HTML specification. The issue is that live-server assumes there is either an `<head>` and `<body>. 

This PR solves this issue by adding an new option: `--inject-eof`. If that option is enabled and `<!DOCTYPE html>` is available, it will inject the script at EOF.




