### PR TITLE
Only re-add actually modified CSS files

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,7 +120,6 @@ function entryPoint(staticHandler, file) {
  * @param watch {array} Paths to exclusively watch for changes
  * @param ignore {array} Paths to ignore when watching files for changes
  * @param ignorePattern {regexp} Ignore files by RegExp
- * @param noCssInject Don't inject CSS changes, just reload as with any other file change
  * @param open {(string|string[])} Subpath(s) to open in browser, use false to suppress launch (default: server root)
  * @param mount {array} Mount directories onto a route, e.g. [['/components', './node_modules']].
  * @param logLevel {number} 0 = errors only, 1 = some, 2 = lots
@@ -149,20 +148,6 @@ LiveServer.start = function(options) {
 	var https = options.https || null;
 	var proxy = options.proxy || [];
 	var middleware = options.middleware || [];
-	var noCssInject = options.noCssInject;
-	var httpsModule = options.httpsModule;
-
-	if (httpsModule) {
-		try {
-			require.resolve(httpsModule);
-		} catch (e) {
-			console.error(("HTTPS module \"" + httpsModule + "\" you've provided was not found.").red);
-			console.error("Did you do", "\"npm install " + httpsModule + "\"?");
-			return;
-		}
-	} else {
-		httpsModule = "https";
-	}
 
 	// Setup a web server
 	var app = connect();
@@ -233,7 +218,7 @@ LiveServer.start = function(options) {
 		if (typeof https === "string") {
 			httpsConfig = require(path.resolve(process.cwd(), https));
 		}
-		server = require(httpsModule).createServer(httpsConfig, app);
+		server = require("https").createServer(httpsConfig, app);
 		protocol = "https";
 	} else {
 		server = http.createServer(app);
@@ -358,15 +343,17 @@ LiveServer.start = function(options) {
 		ignoreInitial: true
 	});
 	function handleChange(changePath) {
-		var cssChange = path.extname(changePath) === ".css" && !noCssInject;
+		var cssChange = path.extname(changePath) === ".css";
 		if (LiveServer.logLevel >= 1) {
 			if (cssChange)
 				console.log("CSS change detected".magenta, changePath);
 			else console.log("Change detected".cyan, changePath);
 		}
 		clients.forEach(function(ws) {
-			if (ws)
-				ws.send(cssChange ? 'refreshcss' : 'reload');
+			if (ws) {
+				var file = changePath.replace(process.cwd()+'/', '');
+				ws.send(cssChange ? 'refreshcss:'+file : 'reload');
+			}
 		});
 	}
 	LiveServer.watcher

--- a/injected.html
+++ b/injected.html
@@ -3,26 +3,24 @@
 	// <![CDATA[  <-- For SVG support
 	if ('WebSocket' in window) {
 		(function() {
-			function refreshCSS() {
-				var sheets = [].slice.call(document.getElementsByTagName("link"));
-				var head = document.getElementsByTagName("head")[0];
-				for (var i = 0; i < sheets.length; ++i) {
-					var elem = sheets[i];
-					head.removeChild(elem);
-					var rel = elem.rel;
-					if (elem.href && typeof rel != "string" || rel.length == 0 || rel.toLowerCase() == "stylesheet") {
-						var url = elem.href.replace(/(&|\?)_cacheOverride=\d+/, '');
-						elem.href = url + (url.indexOf('?') >= 0 ? '&' : '?') + '_cacheOverride=' + (new Date().valueOf());
+			function refreshCSS(file) {
+				var timestamp = new Date().getTime();
+				document.head.insertAdjacentHTML('beforeend', `<link rel="stylesheet" href="${file}" class="cache_${timestamp}">`);
+				document.querySelectorAll(`link[href="${file}"]`).forEach(function(e) {
+					if (!!~e.href.indexOf(file) && e.className !== 'cache_' + timestamp) {
+						setTimeout(function(){e.remove()}, 300);
 					}
-					head.appendChild(elem);
-				}
+				});
 			}
+
 			var protocol = window.location.protocol === 'http:' ? 'ws://' : 'wss://';
 			var address = protocol + window.location.host + window.location.pathname + '/ws';
 			var socket = new WebSocket(address);
 			socket.onmessage = function(msg) {
-				if (msg.data == 'reload') window.location.reload();
-				else if (msg.data == 'refreshcss') refreshCSS();
+				var cmd = msg.data.split(':')[0];
+				var arg = msg.data.split(':')[1];
+				if (cmd == 'reload') window.location.reload();
+				else if (cmd == 'refreshcss') refreshCSS(arg);
 			};
 			console.log('Live reload enabled.');
 		})();


### PR DESCRIPTION
I've changed the behavior of `refreshcss` making it only re-add the `link` tag for the file that was modified, and it is added *before* removing the older, so the screen doesn't blink and the changes are applied smoothly.

Video of this in action: https://youtu.be/DiISDcN1jiE