### PR TITLE
On 404, send a meta refresh header

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,7 +73,19 @@ function staticServer(root) {
 		}
 
 		function error(err) {
-			if (err.status === 404) return next();
+			if (err.status === 404) {
+				var accept = req.headers['accept'];
+				if (accept && accept.indexOf('text/html') >= 0) {
+					res.statusCode = 404;
+					res.end('<html><head><meta http-equiv="refresh" content="1"></head><body>404 not found - will attempt to reload in 1 second</body></html>');
+					return;
+				} else {
+					if (LiveServer.logLevel >= 3) {
+						console.warn("Didn't find text/html in ACCEPT header, so using default handler. ACCEPT header = ", accept);
+					}
+					return next();
+				}
+			}
 			next(err);
 		}
 


### PR DESCRIPTION
# Workaround for 404s causing stuckness

With the static site generator I'm using, other paths get changed before the html of the page I'm viewing.  This would cause the page to reload, but before the html file has been written.  The html file is deleted at the beginning of site regeneration, so this would cause a 404 error.  Since the 404 does not have the change watching script, the browser would get stuck and no longer show a live preview.

I experimented with sending the 404 with the change watching script.  However, this often does not work properly.  What would happen is that the file would get created with size 0, and would be read before it is populated.  This 0 size file would then get served, and this would be another stuckness state.

This is a hacky solution, and I am not very familiar with node.  It works well enough for my usecase, though, so I figured I would open a PR.

# Race condition..

Unfortunately, serving the change watching script when the file is 0 size is not sufficient.  This is because there is a race condition where file changes are ignored during reload.

It looks to me like the implementation of live-server does not have good guarantees of promptly showing the most recent version.   In other words, it is straightforward to trigger a scenario where the browser is viewing an old version of the code.  Here's what happens:

1. A change occurs, notifying the client to reload
2. The client reloads
3. The user makes a change
4. The reload script begins watching for changes again

Between (1) and (4), there is a gap where the client is not made aware of changes, and so the user's change in (3) will be ignored.  My suggestion would be to either add incrementing counters or timestamps to the protocol.  On load of the page, the client should immediately reload if it is already out of date.