### PR TITLE
Change refreshCSS() to load all CSS, not just in head element

### DIFF
--- a/injected.html
+++ b/injected.html
@@ -5,16 +5,15 @@
 		(function() {
 			function refreshCSS() {
 				var sheets = [].slice.call(document.getElementsByTagName("link"));
-				var head = document.getElementsByTagName("head")[0];
 				for (var i = 0; i < sheets.length; ++i) {
-					var elem = sheets[i];
-					head.removeChild(elem);
+					var link = sheets[i];
+					var elem = link.cloneNode(true);
 					var rel = elem.rel;
 					if (elem.href && typeof rel != "string" || rel.length == 0 || rel.toLowerCase() == "stylesheet") {
 						var url = elem.href.replace(/(&|\?)_cacheOverride=\d+/, '');
 						elem.href = url + (url.indexOf('?') >= 0 ? '&' : '?') + '_cacheOverride=' + (new Date().valueOf());
 					}
-					head.appendChild(elem);
+					link.parentElement.replaceChild(elem, link);
 				}
 			}
 			var protocol = window.location.protocol === 'http:' ? 'ws://' : 'wss://';


### PR DESCRIPTION
PR uses `cloneNode` to copy CSS link element, modify the cache property, then replace the copied element under the copied element's parent.

This allows live-server to replace CSS elements in the body, not just the head, of the document.

Note: I'm not sure what's going on with my editor - the only changes are on lines 9, 10, and 16.