### PR TITLE
Reimplementation of --base

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+settings.json
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Command line parameters:
 * `--no-css-inject` - reload page on CSS change, rather than injecting changed CSS
 * `--middleware=PATH` - path to .js file exporting a middleware function to add; can be a name without path nor extension to reference bundled middlewares in `middleware` folder
 * `--entry-file=PATH` - serve this file (server root relative) in place of missing files (useful for single page apps)
+* `--base=BASE` - use this as the base of all URLs on the site
 * `--mount=ROUTE:PATH` - serve the paths contents under the defined route (multiple definitions possible)
 * `--spa` - translate requests from /abc to /#/abc (handy for Single Page Apps)
 * `--wait=MILLISECONDS` - (default 100ms) wait for all changes, before reloading

--- a/live-server.js
+++ b/live-server.js
@@ -36,6 +36,10 @@ for (var i = process.argv.length - 1; i >= 2; --i) {
 		opts.host = arg.substring(7);
 		process.argv.splice(i, 1);
 	}
+	else if (arg.indexOf("--base=") > -1) {
+		opts.base = arg.substring(7);
+		process.argv.splice(i, 1);
+	}
 	else if (arg.indexOf("--open=") > -1) {
 		var open = arg.substring(7);
 		if (open.indexOf('/') !== 0) {
@@ -147,7 +151,7 @@ for (var i = process.argv.length - 1; i >= 2; --i) {
 		process.argv.splice(i, 1);
 	}
 	else if (arg === "--help" || arg === "-h") {
-		console.log('Usage: live-server [-v|--version] [-h|--help] [-q|--quiet] [--port=PORT] [--host=HOST] [--open=PATH] [--no-browser] [--browser=BROWSER] [--ignore=PATH] [--ignorePattern=RGXP] [--no-css-inject] [--entry-file=PATH] [--spa] [--mount=ROUTE:PATH] [--wait=MILLISECONDS] [--htpasswd=PATH] [--cors] [--https=PATH] [--https-module=MODULE_NAME] [--proxy=PATH] [PATH]');
+		console.log('Usage: live-server [-v|--version] [-h|--help] [-q|--quiet] [--port=PORT] [--host=HOST] [--base=BASE] [--open=PATH] [--no-browser] [--browser=BROWSER] [--ignore=PATH] [--ignorePattern=RGXP] [--no-css-inject] [--entry-file=PATH] [--spa] [--mount=ROUTE:PATH] [--wait=MILLISECONDS] [--htpasswd=PATH] [--cors] [--https=PATH] [--https-module=MODULE_NAME] [--proxy=PATH] [PATH]');
 		process.exit();
 	}
 	else if (arg === "--test") {

--- a/test/base.js
+++ b/test/base.js
@@ -1,0 +1,30 @@
+var request = require('supertest');
+var path = require('path');
+var liveServer = require('..').start({
+	root: path.join(__dirname, "data"),
+	port: 0,
+	open: false,
+	base: "alias"
+});
+
+describe('base tests', function() {
+	it('should respond with sub.html', function(done) {
+		request(liveServer)
+			.get('/alias/sub/sub.html')
+			.expect('Content-Type', 'text/html; charset=UTF-8')
+			.expect(/Subdirectory/i)
+			.expect(200, done);
+	});
+	it('should respond with style.css', function(done) {
+		request(liveServer)
+			.get('/alias/style.css')
+			.expect('Content-Type', 'text/css; charset=UTF-8')
+			.expect(/color/i)
+			.expect(200, done);
+	});
+	it('should respond with 404 since we must use base', function(done) {
+		request(liveServer)
+			.get('/')
+			.expect(404, done);
+	});
+});


### PR DESCRIPTION
As described in #287 (and #37), having a `--base` option to specify a base URL would be helpful. I could not see how to implement this feature using `--mount`, though maybe that can be explained to me. One feature of `--base` that I don't think `--mount` would resolve is that anything outside the base URL should be inaccessible and return 404 errors.

This code is based on the already existing [base-url branch](https://github.com/tapio/live-server/tree/base-url), so it should look pretty familiar. I have added functionality to prevent access to paths outside the base, added a test, and updated the `README.md`. There are also minor changes to the `.gitignore` file that make it easier to use the code in a VS Code environment.