### PR TITLE
Add --watch-dotfiles / options.watchDotfiles setting

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,6 +128,7 @@ function entryPoint(staticHandler, file) {
  * @param wait {number} Server will wait for all changes, before reloading
  * @param htpasswd {string} Path to htpasswd file to enable HTTP Basic authentication
  * @param middleware {array} Append middleware to stack, e.g. [function(req, res, next) { next(); }].
+ * @param watchDotfiles Don't ignore changes to files & folders beginning with '.' from the watch directory
  */
 LiveServer.start = function(options) {
 	options = options || {};
@@ -341,20 +342,33 @@ LiveServer.start = function(options) {
 		clients.push(ws);
 	});
 
-	var ignored = [
-		function(testPath) { // Always ignore dotfiles (important e.g. because editor hidden temp files)
-			return testPath !== "." && /(^[.#]|(?:__|~)$)/.test(path.basename(testPath));
+	var ignoredPaths = [
+		function(testPath) { 
+			/*
+				Ignore dotfiles by default (important e.g. because editor
+				hidden temp files), unless options.watchDotfiles is truthy.
+
+				Regex explanation: 
+				- Any relative or absolute path (the first capture group)
+				- starting with a literal '.', and then followed by at least
+				  one character (which excludes the CWD path '.')
+			*/
+			var notDotfileOrCwd = /(^|[\/\\])\../;
+			var ignoreThisPath = options.watchDotfiles ? false : notDotfileOrCwd.test(path.basename(testPath));
+			if (LiveServer.logLevel >= 1)
+				console.log('Watcher ignoring files in path beginning with ".": %s', path.basename(testPath));
+			return ignoreThisPath
 		}
 	];
 	if (options.ignore) {
-		ignored = ignored.concat(options.ignore);
+		ignoredPaths = ignoredPaths.concat(options.ignore);
 	}
 	if (options.ignorePattern) {
-		ignored.push(options.ignorePattern);
+		ignoredPaths.push(options.ignorePattern);
 	}
 	// Setup file watcher
 	LiveServer.watcher = chokidar.watch(watchPaths, {
-		ignored: ignored,
+		ignored: ignoredPaths,
 		ignoreInitial: true
 	});
 	function handleChange(changePath) {

--- a/live-server.js
+++ b/live-server.js
@@ -146,6 +146,10 @@ for (var i = process.argv.length - 1; i >= 2; --i) {
 		opts.middleware.push(arg.substring(13));
 		process.argv.splice(i, 1);
 	}
+	else if (arg === "--watch-dotfiles") {
+		opts.watchDotfiles = true;
+		process.argv.splice(i, 1);
+	}
 	else if (arg === "--help" || arg === "-h") {
 		console.log('Usage: live-server [-v|--version] [-h|--help] [-q|--quiet] [--port=PORT] [--host=HOST] [--open=PATH] [--no-browser] [--browser=BROWSER] [--ignore=PATH] [--ignorePattern=RGXP] [--no-css-inject] [--entry-file=PATH] [--spa] [--mount=ROUTE:PATH] [--wait=MILLISECONDS] [--htpasswd=PATH] [--cors] [--https=PATH] [--https-module=MODULE_NAME] [--proxy=PATH] [PATH]');
 		process.exit();


### PR DESCRIPTION
This stops Chokidar from ignoring paths with files that start with '.', so that users can have
their dev server pointing at a hidden directory (such as the popular '.tmp' from Grunt/Gulp).
Prints a warning when dotfiles get ignored, so users can discover this setting easily.

**Rationale**: there was quite a few issues such as #193 where users had no idea *why* the live-reloads weren't triggering, so I also added console output to let users know when their path had been ignored by Chokidar.

The new regex is taken directly from Chokidar's docs as the example for hiding dotfiles.

**A note on testing**: while this has passed the existing test suite, I noticed that the tests to check whether or not live-reloads were actually happening in-browser were still just 'todo' placeholders, so I couldn't simply adapt your tests for this feature. I'm not familiar with browser testing like PhantomJS yet, and this feature needs something like that to actually test, so there's no new automated test for this feature, sorry!. I did *manually* test it, though, and it works on macOS Mojave 10.14 running Chrome 71.0.3578.98.

This is my first real PR so apologies if I've missed anything! Thanks.

