### PR TITLE
Add closeOnExit flag to close the browser window on server exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Command line parameters:
 * `--https=PATH` - PATH to a HTTPS configuration module
 * `--https-module=MODULE_NAME` - Custom HTTPS module (e.g. `spdy`)
 * `--proxy=ROUTE:URL` - proxy all requests for ROUTE to URL
+* `--closeOnExit` - close browser window on server exit
 * `--help | -h` - display terse usage hint and exit
 * `--version | -v` - display version and exit
 

--- a/index.js
+++ b/index.js
@@ -79,10 +79,12 @@ function staticServer(root, closeOnExit) {
 
 		function inject(stream) {
 			if (injectTag) {
-				var inject=INJECTED_CODE;
-
-				closeOnExit=closeOnExit||false;
-				inject="<script>var __live_server_reload_on_close="+closeOnExit+";</script>\n"+inject;
+				closeOnExit = closeOnExit||false;
+				var injectCode = 
+					"<script>var __live_server_reload_on_close=" +
+					closeOnExit +
+					";</script>\n" +
+					INJECTED_CODE;
 
 				// We need to modify the length given to browser
 				var len = inject.length + res.getHeader('Content-Length');
@@ -90,7 +92,7 @@ function staticServer(root, closeOnExit) {
 				res.setHeader('Cache-Control','no-store, no-cache, must-revalidate');
 				var originalPipe = stream.pipe;
 				stream.pipe = function(resp) {
-					originalPipe.call(stream, es.replace(new RegExp(injectTag, "i"), inject + injectTag)).pipe(resp);
+					originalPipe.call(stream, es.replace(new RegExp(injectTag, "i"), injectCode + injectTag)).pipe(resp);
 				};
 			}
 		}

--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ function staticServer(root, closeOnExit) {
 
 		function inject(stream) {
 			if (injectTag) {
-				closeOnExit = closeOnExit||false;
+				closeOnExit = closeOnExit || false;
 				var injectCode = 
 					"<script>var __live_server_reload_on_close=" +
 					closeOnExit +
@@ -87,7 +87,7 @@ function staticServer(root, closeOnExit) {
 					INJECTED_CODE;
 
 				// We need to modify the length given to browser
-				var len = inject.length + res.getHeader('Content-Length');
+				var len = injectCode.length + res.getHeader('Content-Length');
 				res.setHeader('Content-Length', len);
 				res.setHeader('Cache-Control','no-store, no-cache, must-revalidate');
 				var originalPipe = stream.pipe;

--- a/injected.html
+++ b/injected.html
@@ -24,6 +24,10 @@
 				if (msg.data == 'reload') window.location.reload();
 				else if (msg.data == 'refreshcss') refreshCSS();
 			};
+			socket.onclose = function() {
+				if (__live_server_reload_on_close)
+					window.close();
+			};
 			console.log('Live reload enabled.');
 		})();
 	}

--- a/live-server.js
+++ b/live-server.js
@@ -147,8 +147,8 @@ for (var i = process.argv.length - 1; i >= 2; --i) {
 		process.argv.splice(i, 1);
 	}
 	else if (arg.indexOf("--closeOnExit=") > -1) {
-		if (arg.substring(14)=="true")
-			opts.closeOnExit=true;
+		if (arg.substring(14) === "true")
+			opts.closeOnExit = true;
 		process.argv.splice(i, 1);
 	}
 	else if (arg === "--help" || arg === "-h") {

--- a/live-server.js
+++ b/live-server.js
@@ -146,6 +146,11 @@ for (var i = process.argv.length - 1; i >= 2; --i) {
 		opts.middleware.push(arg.substring(13));
 		process.argv.splice(i, 1);
 	}
+	else if (arg.indexOf("--closeOnExit=") > -1) {
+		if (arg.substring(14)=="true")
+			opts.closeOnExit=true;
+		process.argv.splice(i, 1);
+	}
 	else if (arg === "--help" || arg === "-h") {
 		console.log('Usage: live-server [-v|--version] [-h|--help] [-q|--quiet] [--port=PORT] [--host=HOST] [--open=PATH] [--no-browser] [--browser=BROWSER] [--ignore=PATH] [--ignorePattern=RGXP] [--no-css-inject] [--entry-file=PATH] [--spa] [--mount=ROUTE:PATH] [--wait=MILLISECONDS] [--htpasswd=PATH] [--cors] [--https=PATH] [--https-module=MODULE_NAME] [--proxy=PATH] [PATH]');
 		process.exit();

--- a/live-server.js
+++ b/live-server.js
@@ -146,9 +146,8 @@ for (var i = process.argv.length - 1; i >= 2; --i) {
 		opts.middleware.push(arg.substring(13));
 		process.argv.splice(i, 1);
 	}
-	else if (arg.indexOf("--closeOnExit=") > -1) {
-		if (arg.substring(14) === "true")
-			opts.closeOnExit = true;
+	else if (arg.indexOf("--closeOnExit") > -1) {
+		opts.closeOnExit = true;
 		process.argv.splice(i, 1);
 	}
 	else if (arg === "--help" || arg === "-h") {


### PR DESCRIPTION
This PR adds the option closeOnExit. When the option is active, code gets injected into the client that  closes the window when the WebSocket to the server closes.

The reason for this is that if `live-server` is used together with tools such as `nodemon` to reload the server side, then the browser will eventually end up with a great number of windows open, since a new window will be opened each time `live-server` is started. 