### PR TITLE
Use specific URL for the reload web socket

### DIFF
--- a/index.js
+++ b/index.js
@@ -315,6 +315,10 @@ LiveServer.start = function(options) {
 	// WebSocket
 	var clients = [];
 	server.addListener('upgrade', function(request, socket, head) {
+
+		// Ignore requests that are not from `/live-server-socket` URLs
+		if (!/\/live-server-socket$/.test(request.url)) return;
+
 		var ws = new WebSocket(request, socket, head);
 		ws.onopen = function() { ws.send('connected'); };
 

--- a/injected.html
+++ b/injected.html
@@ -18,7 +18,7 @@
 				}
 			}
 			var protocol = window.location.protocol === 'http:' ? 'ws://' : 'wss://';
-			var address = protocol + window.location.host + window.location.pathname + '/ws';
+			var address = protocol + window.location.host + window.location.pathname + '/live-server-socket';
 			var socket = new WebSocket(address);
 			socket.onmessage = function(msg) {
 				if (msg.data == 'reload') window.location.reload();


### PR DESCRIPTION
I'm using `live-server` to serve static files and then have it proxying an API also, that API has a web socket endpoint, but it's unreachable at the moment as any web socket connection attempts made to the `live-server` will be grabbed by the reload socket. 

This PR gives the reload socket endpoint in the injected code a slightly less generic name (in the hopes of avoiding potential overlaps) and adds a check to only connect the reload handling stuff if the request matches the name, allowing middleware or other things to pick up other socket requests as necessary.