### PR TITLE
Update python http module to favor python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ There are two reasons for using this:
 
 You don't need to install any browser plugins or manually add code snippets to your pages for the reload functionality to work, see "How it works" section below for more information. If you don't want/need the live reload, you should probably use something even simpler, like the following Python-based one-liner:
 
-	python -m SimpleHTTPServer
+	python -m http.server
 
 
 Installation


### PR DESCRIPTION
This may not be necessary but given that python2 will start to phase out in 2020, perhaps this should instruct people to use the python3 version of the simple server one liner