### PR TITLE
Working dir resolution for middleware

### DIFF
--- a/index.js
+++ b/index.js
@@ -186,7 +186,7 @@ LiveServer.start = function(options) {
 			if (ext !== ".js") {
 				mw = require(path.join(__dirname, "middleware", mw + ".js"));
 			} else {
-				mw = require(mw);
+				mw = require(process.cwd() + '/' + mw);
 			}
 		}
 		app.use(mw);


### PR DESCRIPTION
Prepend process.cwd() to to supplied middleware path in order to resolve the working directory from cli execution.

I'm unsure what the point of the bare `require(mw)` statement was, as I found it hard pressed to match anything useful other than absolute paths. If you believe this is required to maintain backwards compat, let me know and I will rethink the PR.