### PR TITLE
Use String#includes instead of String#indexOf

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ function staticServer(root) {
 		function file(filepath /*, stat*/) {
 			var x = path.extname(filepath).toLocaleLowerCase(), match,
 					possibleExtensions = [ "", ".html", ".htm", ".xhtml", ".php", ".svg" ];
-			if (hasNoOrigin && (possibleExtensions.indexOf(x) > -1)) {
+			if (hasNoOrigin && possibleExtensions.includes(x)) {
 				// TODO: Sync file read here is not nice, but we need to determine if the html should be injected or not
 				var contents = fs.readFileSync(filepath, "utf8");
 				for (var i = 0; i < injectCandidates.length; ++i) {

--- a/injected.html
+++ b/injected.html
@@ -12,7 +12,7 @@
 					var rel = elem.rel;
 					if (elem.href && typeof rel != "string" || rel.length == 0 || rel.toLowerCase() == "stylesheet") {
 						var url = elem.href.replace(/(&|\?)_cacheOverride=\d+/, '');
-						elem.href = url + (url.indexOf('?') >= 0 ? '&' : '?') + '_cacheOverride=' + (new Date().valueOf());
+						elem.href = url + (url.includes('?') ? '&' : '?') + '_cacheOverride=' + (new Date().valueOf());
 					}
 					head.appendChild(elem);
 				}

--- a/live-server.js
+++ b/live-server.js
@@ -24,7 +24,7 @@ if (fs.existsSync(configPath)) {
 
 for (var i = process.argv.length - 1; i >= 2; --i) {
 	var arg = process.argv[i];
-	if (arg.indexOf("--port=") > -1) {
+	if (arg.includes("--port=")) {
 		var portString = arg.substring(7);
 		var portNumber = parseInt(portString, 10);
 		if (portNumber === +portString) {
@@ -32,11 +32,11 @@ for (var i = process.argv.length - 1; i >= 2; --i) {
 			process.argv.splice(i, 1);
 		}
 	}
-	else if (arg.indexOf("--host=") > -1) {
+	else if (arg.includes("--host=")) {
 		opts.host = arg.substring(7);
 		process.argv.splice(i, 1);
 	}
-	else if (arg.indexOf("--open=") > -1) {
+	else if (arg.includes("--open=")) {
 		var open = arg.substring(7);
 		if (open.indexOf('/') !== 0) {
 			open = '/' + open;
@@ -54,17 +54,17 @@ for (var i = process.argv.length - 1; i >= 2; --i) {
 		}
 		process.argv.splice(i, 1);
 	}
-	else if (arg.indexOf("--watch=") > -1) {
+	else if (arg.includes("--watch=")) {
 		// Will be modified later when cwd is known
 		opts.watch = arg.substring(8).split(",");
 		process.argv.splice(i, 1);
 	}
-	else if (arg.indexOf("--ignore=") > -1) {
+	else if (arg.includes("--ignore=")) {
 		// Will be modified later when cwd is known
 		opts.ignore = arg.substring(9).split(",");
 		process.argv.splice(i, 1);
 	}
-	else if (arg.indexOf("--ignorePattern=") > -1) {
+	else if (arg.includes("--ignorePattern=")) {
 		opts.ignorePattern = new RegExp(arg.substring(16));
 		process.argv.splice(i, 1);
 	}
@@ -76,11 +76,11 @@ for (var i = process.argv.length - 1; i >= 2; --i) {
 		opts.open = false;
 		process.argv.splice(i, 1);
 	}
-	else if (arg.indexOf("--browser=") > -1) {
+	else if (arg.includes("--browser=")) {
 		opts.browser = arg.substring(10).split(",");
 		process.argv.splice(i, 1);
 	}
-	else if (arg.indexOf("--entry-file=") > -1) {
+	else if (arg.includes("--entry-file=")) {
 		var file = arg.substring(13);
 		if (file.length) {
 			opts.file = file;
@@ -99,7 +99,7 @@ for (var i = process.argv.length - 1; i >= 2; --i) {
 		opts.logLevel = 3;
 		process.argv.splice(i, 1);
 	}
-	else if (arg.indexOf("--mount=") > -1) {
+	else if (arg.includes("--mount=")) {
 		// e.g. "--mount=/components:./node_modules" will be ['/components', '<process.cwd()>/node_modules']
 		// split only on the first ":", as the path may contain ":" as well (e.g. C:\file.txt)
 		var match = arg.substring(8).match(/([^:]+):(.+)$/);
@@ -107,7 +107,7 @@ for (var i = process.argv.length - 1; i >= 2; --i) {
 		opts.mount.push([ match[1], match[2] ]);
 		process.argv.splice(i, 1);
 	}
-	else if (arg.indexOf("--wait=") > -1) {
+	else if (arg.includes("--wait=")) {
 		var waitString = arg.substring(7);
 		var waitNumber = parseInt(waitString, 10);
 		if (waitNumber === +waitString) {
@@ -120,7 +120,7 @@ for (var i = process.argv.length - 1; i >= 2; --i) {
 		console.log(packageJson.name, packageJson.version);
 		process.exit();
 	}
-	else if (arg.indexOf("--htpasswd=") > -1) {
+	else if (arg.includes("--htpasswd=")) {
 		opts.htpasswd = arg.substring(11);
 		process.argv.splice(i, 1);
 	}
@@ -128,21 +128,21 @@ for (var i = process.argv.length - 1; i >= 2; --i) {
 		opts.cors = true;
 		process.argv.splice(i, 1);
 	}
-	else if (arg.indexOf("--https=") > -1) {
+	else if (arg.includes("--https=")) {
 		opts.https = arg.substring(8);
 		process.argv.splice(i, 1);
 	}
-	else if (arg.indexOf("--https-module=") > -1) {
+	else if (arg.includes("--https-module=")) {
 		opts.httpsModule = arg.substring(15);
 		process.argv.splice(i, 1);
 	}
-	else if (arg.indexOf("--proxy=") > -1) {
+	else if (arg.includes("--proxy=")) {
 		// split only on the first ":", as the URL will contain ":" as well
 		var match = arg.substring(8).match(/([^:]+):(.+)$/);
 		opts.proxy.push([ match[1], match[2] ]);
 		process.argv.splice(i, 1);
 	}
-	else if (arg.indexOf("--middleware=") > -1) {
+	else if (arg.includes("--middleware=")) {
 		opts.middleware.push(arg.substring(13));
 		process.argv.splice(i, 1);
 	}

--- a/test/acceptance.js
+++ b/test/acceptance.js
@@ -40,7 +40,7 @@ describe('basic functional tests', function(){
 			.get('/test.svg')
 			.expect('Content-Type', 'image/svg+xml')
 			.expect(function(res) {
-				if (res.body.toString().indexOf("Live reload enabled") == -1)
+				if (!res.body.toString().includes("Live reload enabled"))
 					throw new Error("injected code not found");
 			})
 			.expect(200, done);
@@ -50,7 +50,7 @@ describe('basic functional tests', function(){
 			.get('/fragment.html')
 			.expect('Content-Type', 'text/html; charset=UTF-8')
 			.expect(function(res) {
-				if (res.text.toString().indexOf("Live reload enabled") > -1)
+				if (res.text.toString().includes("Live reload enabled"))
 					throw new Error("injected code should not be found");
 			})
 			.expect(200, done);

--- a/test/cli.js
+++ b/test/cli.js
@@ -17,14 +17,14 @@ describe('command line usage', function() {
 	it('--version', function(done) {
 		exec_test([ "--version" ], function(error, stdout, stdin) {
 			assert(!error, error);
-			assert(stdout.indexOf("live-server") === 0, "version not found");
+			assert(stdout.includes("live-server"), "version not found");
 			done();
 		});
 	});
 	it('--help', function(done) {
 		exec_test([ "--help" ], function(error, stdout, stdin) {
 			assert(!error, error);
-			assert(stdout.indexOf("Usage: live-server") === 0, "usage not found");
+			assert(stdout.includes("Usage: live-server"), "usage not found");
 			done();
 		});
 	});
@@ -38,16 +38,16 @@ describe('command line usage', function() {
 	it('--port', function(done) {
 		exec_test([ "--port=16123", "--no-browser", "--test" ], function(error, stdout, stdin) {
 			assert(!error, error);
-			assert(stdout.indexOf("Serving") >= 0, "serving string not found");
-			assert(stdout.indexOf("at http://127.0.0.1:16123") != -1, "port string not found");
+			assert(stdout.includes("Serving"), "serving string not found");
+			assert(stdout.includes("at http://127.0.0.1:16123"), "port string not found");
 			done();
 		});
 	});
 	it('--host', function(done) {
 		exec_test([ "--host=localhost", "--no-browser", "--test" ], function(error, stdout, stdin) {
 			assert(!error, error);
-			assert(stdout.indexOf("Serving") >= 0, "serving string not found");
-			assert(stdout.indexOf("at http://localhost:") != -1, "host string not found");
+			assert(stdout.includes("Serving"), "serving string not found");
+			assert(stdout.includes("at http://localhost:"), "host string not found");
 			done();
 		});
 	});
@@ -58,7 +58,7 @@ describe('command line usage', function() {
 				"--test"
 			], function(error, stdout, stdin) {
 			assert(!error, error);
-			assert(stdout.indexOf("Serving") >= 0, "serving string not found");
+			assert(stdout.includes("Serving"), "serving string not found");
 			done();
 		});
 	});


### PR DESCRIPTION
Fixes #336 

In all instances where `String#indexOf` was used to determine if a substring existed, I replaced the calls with `String#includes`.

Affected files:
- live-server.js
- test/cli.js
- test/acceptance.js
- injected.html
- index.js

All tests passed locally with all the changes in this PR 👍 