### PR TITLE
Added beforeReload hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ var params = {
 	wait: 1000, // Waits for all changes, before reloading. Defaults to 0 sec.
 	mount: [['/components', './node_modules']], // Mount a directory to a route.
 	logLevel: 2, // 0 = errors only, 1 = some, 2 = lots
-	middleware: [function(req, res, next) { next(); }] // Takes an array of Connect-compatible middleware that are injected into the server middleware stack
+	middleware: [function(req, res, next) { next(); }], // Takes an array of Connect-compatible middleware that are injected into the server middleware stack
+	beforeReload: function(changePath) { console.log(changePath); }, // Run function every time a change is detected. Return a Promise to delay browser reload.
 };
 liveServer.start(params);
 ```


### PR DESCRIPTION
Add `beforeReload` option.
Now you can run a javascript function every time a change is detected.

Example:
```javascript
liveServer.start({
  beforeReload: (changePath) => { 
    console.log(changePath + " file has changed! Reloading...")
  } 
});
```

It supports Promises and async functions too:
```javascript
liveServer.start({
  beforeReload: async(changePath) => { 
    /* await some async resource
      the page will not reload until the resource is ready */
  } 
});
```
