### PR TITLE
Fix exception when homeDir is not available

### DIFF
--- a/live-server.js
+++ b/live-server.js
@@ -15,11 +15,13 @@ var opts = {
 };
 
 var homeDir = process.env[(process.platform === 'win32') ? 'USERPROFILE' : 'HOME'];
-var configPath = path.join(homeDir, '.live-server.json');
-if (fs.existsSync(configPath)) {
-	var userConfig = fs.readFileSync(configPath, 'utf8');
-	assign(opts, JSON.parse(userConfig));
-	if (opts.ignorePattern) opts.ignorePattern = new RegExp(opts.ignorePattern);
+if (homeDir != null) {
+	var configPath = path.join(homeDir, '.live-server.json');
+	if (fs.existsSync(configPath)) {
+		var userConfig = fs.readFileSync(configPath, 'utf8');
+		assign(opts, JSON.parse(userConfig));
+		if (opts.ignorePattern) opts.ignorePattern = new RegExp(opts.ignorePattern);
+	}
 }
 
 for (var i = process.argv.length - 1; i >= 2; --i) {


### PR DESCRIPTION
I encountered a crash when running live-server from a systemd service, and tracked the issue to loading the config from a user's home folder

https://github.com/tapio/live-server/blob/01cd7f970439d42537bbe13b4885befb816a0446/live-server.js#L17-L23

In systemd services, the HOME variable is not present, which causes the issue.

This PR fixes it by verifying the variable is non-empty before loading a user's config.