### PR TITLE
Stable "colors" package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "Tapio Vierros",
   "dependencies": {
     "chokidar": "^2.0.4",
-    "colors": "latest",
+    "colors": "1.4.0",
     "connect": "^3.6.6",
     "cors": "latest",
     "event-stream": "3.3.4",


### PR DESCRIPTION
This is an urgent fix, because of updated latest "colors" package version from "1.4.0" to "1.4.44-liberty-2", console is full non-stop trash output.