### PR TITLE
Replace colors.js with chalk

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,8 +11,8 @@ var fs = require('fs'),
 	open = require('opn'),
 	es = require("event-stream"),
 	os = require('os'),
-	chokidar = require('chokidar');
-require('colors');
+	chokidar = require('chokidar'),
+	chalk = require('chalk');
 
 var INJECTED_CODE = fs.readFileSync(path.join(__dirname, "injected.html"), "utf8");
 
@@ -66,7 +66,7 @@ function staticServer(root) {
 					}
 				}
 				if (injectTag === null && LiveServer.logLevel >= 3) {
-					console.warn("Failed to inject refresh script!".yellow,
+					console.warn(chalk.yellow("Failed to inject refresh script!"),
 						"Couldn't find any of the tags ", injectCandidates, "from", filepath);
 				}
 			}
@@ -156,7 +156,7 @@ LiveServer.start = function(options) {
 		try {
 			require.resolve(httpsModule);
 		} catch (e) {
-			console.error(("HTTPS module \"" + httpsModule + "\" you've provided was not found.").red);
+			console.error(chalk.red("HTTPS module \"" + httpsModule + "\" you've provided was not found."));
 			console.error("Did you do", "\"npm install " + httpsModule + "\"?");
 			return;
 		}
@@ -244,12 +244,12 @@ LiveServer.start = function(options) {
 	server.addListener('error', function(e) {
 		if (e.code === 'EADDRINUSE') {
 			var serveURL = protocol + '://' + host + ':' + port;
-			console.log('%s is already in use. Trying another port.'.yellow, serveURL);
+			console.log(chalk.yellow('%s is already in use. Trying another port.'), serveURL);
 			setTimeout(function() {
 				server.listen(0, host);
 			}, 1000);
 		} else {
-			console.error(e.toString().red);
+			console.error(chalk.red(e.toString()));
 			LiveServer.shutdown();
 		}
 	});
@@ -290,12 +290,12 @@ LiveServer.start = function(options) {
 		if (LiveServer.logLevel >= 1) {
 			if (serveURL === openURL)
 				if (serveURLs.length === 1) {
-					console.log(("Serving \"%s\" at %s").green, root, serveURLs[0]);
+					console.log(chalk.green("Serving \"%s\" at %s"), root, serveURLs[0]);
 				} else {
-					console.log(("Serving \"%s\" at\n\t%s").green, root, serveURLs.join("\n\t"));
+					console.log(chalk.green("Serving \"%s\" at\n\t%s"), root, serveURLs.join("\n\t"));
 				}
 			else
-				console.log(("Serving \"%s\" at %s (%s)").green, root, openURL, serveURL);
+				console.log(chalk.green("Serving \"%s\" at %s (%s)"), root, openURL, serveURL);
 		}
 
 		// Launch browser
@@ -361,8 +361,8 @@ LiveServer.start = function(options) {
 		var cssChange = path.extname(changePath) === ".css" && !noCssInject;
 		if (LiveServer.logLevel >= 1) {
 			if (cssChange)
-				console.log("CSS change detected".magenta, changePath);
-			else console.log("Change detected".cyan, changePath);
+				console.log(chalk.magenta("CSS change detected"), changePath);
+			else console.log(chalk.cyan("Change detected"), changePath);
 		}
 		clients.forEach(function(ws) {
 			if (ws)
@@ -377,10 +377,10 @@ LiveServer.start = function(options) {
 		.on("unlinkDir", handleChange)
 		.on("ready", function () {
 			if (LiveServer.logLevel >= 1)
-				console.log("Ready for changes".cyan);
+				console.log(chalk.cyan("Ready for changes"));
 		})
 		.on("error", function (err) {
-			console.log("ERROR:".red, err);
+			console.log(chalk.red("ERROR:"), err);
 		});
 
 	return server;

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   ],
   "author": "Tapio Vierros",
   "dependencies": {
+    "chalk": "^4.1.2",
     "chokidar": "^2.0.4",
-    "colors": "latest",
     "connect": "^3.6.6",
     "cors": "latest",
     "event-stream": "3.3.4",


### PR DESCRIPTION
This PR replaces the `colors.js` dependency (which is having certain issues, see https://github.com/Marak/colors.js/issues/285) with https://github.com/chalk/chalk.

I hope I found all of the coloring invocations.