### PR TITLE
fix: force line endings to lf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Enforce Unix newlines
+* text=auto eol=lf


### PR DESCRIPTION
- Published node executable must be lf

Fixes #394.

```bash
$ grep version node_modules/live-server/package.json
  "version": "1.2.2",
$ file node_modules/.bin/live-server 
node_modules/.bin/live-server: a /usr/bin/env node script text executable, ASCII text, with very long lines (374), with CRLF line terminators

$ grep version node_modules/live-server/package.json
  "version": "1.2.1",
$ file node_modules/.bin/live-server 
node_modules/.bin/live-server: a /usr/bin/env node script text executable, ASCII text, with very long lines (374)
```