### PR TITLE
Polling option for file watch to support usage in WSL 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Command line parameters:
 * `--https=PATH` - PATH to a HTTPS configuration module
 * `--https-module=MODULE_NAME` - Custom HTTPS module (e.g. `spdy`)
 * `--proxy=ROUTE:URL` - proxy all requests for ROUTE to URL
+* `--poll` - use polling for file watch
 * `--help | -h` - display terse usage hint and exit
 * `--version | -v` - display version and exit
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Command line parameters:
 * `--https=PATH` - PATH to a HTTPS configuration module
 * `--https-module=MODULE_NAME` - Custom HTTPS module (e.g. `spdy`)
 * `--proxy=ROUTE:URL` - proxy all requests for ROUTE to URL
-* `--poll` - use polling for file watch
+* `--poll` - use polling to watch files
 * `--help | -h` - display terse usage hint and exit
 * `--version | -v` - display version and exit
 
@@ -89,7 +89,8 @@ var params = {
 	wait: 1000, // Waits for all changes, before reloading. Defaults to 0 sec.
 	mount: [['/components', './node_modules']], // Mount a directory to a route.
 	logLevel: 2, // 0 = errors only, 1 = some, 2 = lots
-	middleware: [function(req, res, next) { next(); }] // Takes an array of Connect-compatible middleware that are injected into the server middleware stack
+	middleware: [function(req, res, next) { next(); }], // Takes an array of Connect-compatible middleware that are injected into the server middleware stack
+	poll: true // When true, will use polling to watch files. 
 };
 liveServer.start(params);
 ```

--- a/index.js
+++ b/index.js
@@ -151,6 +151,7 @@ LiveServer.start = function(options) {
 	var middleware = options.middleware || [];
 	var noCssInject = options.noCssInject;
 	var httpsModule = options.httpsModule;
+	var poll = options.poll || false;
 
 	if (httpsModule) {
 		try {
@@ -354,6 +355,7 @@ LiveServer.start = function(options) {
 	}
 	// Setup file watcher
 	LiveServer.watcher = chokidar.watch(watchPaths, {
+		usePolling: poll,
 		ignored: ignored,
 		ignoreInitial: true
 	});

--- a/live-server.js
+++ b/live-server.js
@@ -12,6 +12,7 @@ var opts = {
 	proxy: [],
 	middleware: [],
 	logLevel: 2,
+	poll: false
 };
 
 var homeDir = process.env[(process.platform === 'win32') ? 'USERPROFILE' : 'HOME'];
@@ -146,8 +147,12 @@ for (var i = process.argv.length - 1; i >= 2; --i) {
 		opts.middleware.push(arg.substring(13));
 		process.argv.splice(i, 1);
 	}
+	else if (arg === "--poll") {
+		opts.poll = true;
+		process.argv.splice(i, 1);
+	}
 	else if (arg === "--help" || arg === "-h") {
-		console.log('Usage: live-server [-v|--version] [-h|--help] [-q|--quiet] [--port=PORT] [--host=HOST] [--open=PATH] [--no-browser] [--browser=BROWSER] [--ignore=PATH] [--ignorePattern=RGXP] [--no-css-inject] [--entry-file=PATH] [--spa] [--mount=ROUTE:PATH] [--wait=MILLISECONDS] [--htpasswd=PATH] [--cors] [--https=PATH] [--https-module=MODULE_NAME] [--proxy=PATH] [PATH]');
+		console.log('Usage: live-server [-v|--version] [-h|--help] [-q|--quiet] [--port=PORT] [--host=HOST] [--open=PATH] [--no-browser] [--browser=BROWSER] [--ignore=PATH] [--ignorePattern=RGXP] [--no-css-inject] [--entry-file=PATH] [--spa] [--mount=ROUTE:PATH] [--wait=MILLISECONDS] [--htpasswd=PATH] [--cors] [--https=PATH] [--https-module=MODULE_NAME] [--proxy=PATH] [--poll] [PATH]');
 		process.exit();
 	}
 	else if (arg === "--test") {


### PR DESCRIPTION
Motivation: The method used by live-server to track file changes doesn't work in the Windows Subsystem for Linux V2 ([see here for details](https://github.com/microsoft/WSL/issues/4739)). This can be fixed by enabling the `usePolling` option in chokidar. 

Changes: Add `--poll` command line and `poll` API options to live-server, set to `false` by default, which enable `usePolling` in chokidar. Update documentation.

